### PR TITLE
Toggle Audio Button and Refactoring For Less Redundant Code

### DIFF
--- a/src/views/LearnToPlay/LearnToPlay.styl
+++ b/src/views/LearnToPlay/LearnToPlay.styl
@@ -152,6 +152,12 @@
     .chapter-text {
         position: absolute;
         color: #fff;
+        cursor: pointer;
+        user-select: none;
+
+        &:hover {
+            color: orange;
+        }
     }
 
     .chapter-1-text {
@@ -164,7 +170,7 @@
          1px -1px 0 #000,
         -1px  1px 0 #000,
          1px  1px 0 #000;
-         background-color: white;
+         background-color: #D4F1F4;
          padding: 5px;
          border-radius: 15px;
     }
@@ -179,7 +185,7 @@
          1px -1px 0 #000,
         -1px  1px 0 #000,
          1px  1px 0 #000;
-         background-color: white;
+         background-color: #D4F1F4;
          padding: 5px;
          border-radius: 15px;
     }
@@ -194,7 +200,7 @@
          1px -1px 0 #000,
         -1px  1px 0 #000,
          1px  1px 0 #000;
-         background-color: white;
+         background-color: #D4F1F4;
          padding: 5px;
          border-radius: 15px;
     }
@@ -209,13 +215,13 @@
          1px -1px 0 #000,
         -1px  1px 0 #000,
          1px  1px 0 #000;
-         background-color: white;
+         background-color: #D4F1F4;
          padding: 5px;
          border-radius: 15px;
     }
 
     .chapter-5-text {
-        right: 38%;
+        left: 43%;
         bottom: 6%;
         color: rgb(255, 204, 102);
         font-weight: bold;
@@ -224,7 +230,7 @@
          1px -1px 0 #000,
         -1px  1px 0 #000,
          1px  1px 0 #000;
-         background-color: white;
+         background-color: #D4F1F4;
          padding: 5px;
          border-radius: 15px;
     }
@@ -238,7 +244,7 @@
          1px -1px 0 #000,
         -1px  1px 0 #000,
          1px  1px 0 #000;
-         background-color: white;
+         background-color: #D4F1F4;
          padding: 5px;
          border-radius: 15px;
     }
@@ -252,7 +258,7 @@
          1px -1px 0 #000,
         -1px  1px 0 #000,
          1px  1px 0 #000;
-         background-color: white;
+         background-color: #D4F1F4;
          padding: 5px;
          border-radius: 15px;
     }
@@ -266,7 +272,7 @@
          1px -1px 0 #000,
         -1px  1px 0 #000,
          1px  1px 0 #000;
-         background-color: white;
+         background-color: #D4F1F4;
          padding: 5px;
          border-radius: 15px;
     }

--- a/src/views/LearnToPlay/LearnToPlay.tsx
+++ b/src/views/LearnToPlay/LearnToPlay.tsx
@@ -40,15 +40,40 @@ export function LearnToPlay(): JSX.Element {
                 <div className="back-background" />
                 <div className="background">
                     <ChapterButton chapter={1} />
-                    <div className="chapter-text chapter-1-text">Capturing Stones</div>
+                    <div
+                        className="chapter-text chapter-1-text"
+                        onClick={() => navigateToChapter(1, navigate)}
+                    >
+                        Capturing Stones
+                    </div>
                     <ChapterButton chapter={2} />
-                    <div className="chapter-text chapter-2-text">Quest for Space</div>
+                    <div
+                        className="chapter-text chapter-2-text"
+                        onClick={() => navigateToChapter(2, navigate)}
+                    >
+                        Quest for Space
+                    </div>
                     <ChapterButton chapter={3} />
-                    <div className="chapter-text chapter-3-text">Eyes for Life</div>
+                    <div
+                        className="chapter-text chapter-3-text"
+                        onClick={() => navigateToChapter(3, navigate)}
+                    >
+                        Eyes for Life
+                    </div>
                     <ChapterButton chapter={4} />
-                    <div className="chapter-text chapter-4-text">Ko Battles</div>
+                    <div
+                        className="chapter-text chapter-4-text"
+                        onClick={() => navigateToChapter(4, navigate)}
+                    >
+                        Ko Battles
+                    </div>
                     <ChapterButton chapter={5} />
-                    <div className="chapter-text chapter-5-text">Magic Moves</div>
+                    <div
+                        className="chapter-text chapter-5-text"
+                        onClick={() => navigateToChapter(5, navigate)}
+                    >
+                        Magic Moves
+                    </div>
                     <ChapterButton chapter={6} />
                     <div className="chapter-text chapter-6-text">Coming Soon</div>
                     <ChapterButton chapter={7} />
@@ -60,6 +85,12 @@ export function LearnToPlay(): JSX.Element {
             <div className="spacer" />
         </div>
     );
+}
+
+function navigateToChapter(chapter: number, navigate) {
+    if (chapter <= 5) {
+        navigate(`/learn-to-play/${chapter}`);
+    }
 }
 
 export function ChapterButton({ chapter }: { chapter: number }): JSX.Element {

--- a/src/views/Lessons/Content.tsx
+++ b/src/views/Lessons/Content.tsx
@@ -36,12 +36,10 @@ export class Content extends TypedEventEmitter<Events> {
     goban?: Goban;
     current_delay: number = 0;
     next_path: string = "";
-    // audioRef: React.RefObject<HTMLAudioElement>;
+    audioUrl: string = "";
 
     constructor() {
-        // constructor(audioRef: React.RefObject<HTMLAudioElement>) {
         super();
-        // this.audioRef = audioRef;
     }
 
     text(): JSX.Element | Array<JSX.Element> {

--- a/src/views/Lessons/Content.tsx
+++ b/src/views/Lessons/Content.tsx
@@ -37,9 +37,11 @@ export class Content extends TypedEventEmitter<Events> {
     current_delay: number = 0;
     next_path: string = "";
     audioUrl: string = "";
+    isPlayingAudio: boolean;
 
-    constructor() {
+    constructor(isPlayingAudio: boolean = true) {
         super();
+        this.isPlayingAudio = isPlayingAudio;
     }
 
     text(): JSX.Element | Array<JSX.Element> {

--- a/src/views/Lessons/Content.tsx
+++ b/src/views/Lessons/Content.tsx
@@ -36,9 +36,12 @@ export class Content extends TypedEventEmitter<Events> {
     goban?: Goban;
     current_delay: number = 0;
     next_path: string = "";
+    // audioRef: React.RefObject<HTMLAudioElement>;
 
     constructor() {
+        // constructor(audioRef: React.RefObject<HTMLAudioElement>) {
         super();
+        // this.audioRef = audioRef;
     }
 
     text(): JSX.Element | Array<JSX.Element> {

--- a/src/views/Lessons/Content.tsx
+++ b/src/views/Lessons/Content.tsx
@@ -37,11 +37,11 @@ export class Content extends TypedEventEmitter<Events> {
     current_delay: number = 0;
     next_path: string = "";
     audioUrl: string = "";
-    isPlayingAudio: boolean;
+    shouldPlayAudio: boolean;
 
-    constructor(isPlayingAudio: boolean = true) {
+    constructor(shouldPlayAudio: boolean = true) {
         super();
-        this.isPlayingAudio = isPlayingAudio;
+        this.shouldPlayAudio = shouldPlayAudio;
     }
 
     text(): JSX.Element | Array<JSX.Element> {

--- a/src/views/Lessons/Lesson.tsx
+++ b/src/views/Lessons/Lesson.tsx
@@ -295,7 +295,7 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
                     <div id="left-container">
                         <div className="explanation-text" onClick={cancel_animation_ref.current}>
                             <button onClick={toggleAudio}>
-                                {isPlayingAudio ? "Stop Audio" : "Play Audio"}
+                                {isPlayingAudio ? "Mute Audio" : "Play Audio"}
                             </button>
                             <audio ref={audioRef} style={{ display: "none" }} />
                             {text}

--- a/src/views/Lessons/Lesson.tsx
+++ b/src/views/Lessons/Lesson.tsx
@@ -102,9 +102,15 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
 
     useEffect(() => {
         console.log("Constructing game ", chapter, page);
-        const content = new chapters[chapter][page]();
-        // const content = new chapters[chapter][page](audioRef);
+        const content = new chapters[chapter][page]() as any;
 
+        // Set up audio
+        if (audioRef.current) {
+            audioRef.current.src = content.audioUrl;
+            if (isPlayingAudio) {
+                audioRef.current.play();
+            }
+        }
         let ct = 0;
 
         const target_text: Array<JSX.Element> = (
@@ -269,23 +275,15 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
         };
     }, [chapter, page, replay, isPlayingAudio]);
 
-    const toggleAudio = async () => {
-        const audio = audioRef?.current;
-
-        if (isPlayingAudio) {
-            // console.log("hit here 1.");
-            // if (audio) {
-            //     console.log("hit here 2.");
-            //     console.log("audioRef.current 22222", audioRef.current);
-            //     audio.pause();
-            //     audio.currentTime = 0;
-            // }
-            setIsPlayingAudio(false);
-        } else {
-            // if (audio) {
-            //     await audio.play();
-            // }
-            setIsPlayingAudio(true);
+    const toggleAudio = () => {
+        const audio = audioRef.current;
+        if (audio) {
+            if (isPlayingAudio) {
+                audio.pause();
+            } else {
+                audio.play();
+            }
+            setIsPlayingAudio(!isPlayingAudio);
         }
     };
 
@@ -303,17 +301,7 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
                             <button onClick={toggleAudio}>
                                 {isPlayingAudio ? "Stop Audio" : "Play Audio"}
                             </button>
-                            {/* <audio
-                                key="audioElement"
-                                ref={audioRef}
-                                style={{ visibility: "hidden" }}
-                                autoPlay={true} // This line auto plays the audio when we click the next button to navigate to the next page
-                                // src={audioUrl}
-                            ></audio> */}
-                            {/* <audio
-                                ref={audioRef}
-                                style={{ visibility: "hidden" }}
-                            ></audio> */}
+                            <audio ref={audioRef} style={{ display: "none" }} />
                             {text}
                             {/* {text.map((e, idx) => (
                                 <div className="fade-in" key={idx}>

--- a/src/views/Lessons/Lesson.tsx
+++ b/src/views/Lessons/Lesson.tsx
@@ -77,7 +77,7 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
     const [showAxotol, setShowAxotol]: [boolean, (x: boolean) => void] = useState<boolean>(false);
     const [hidePlayButton, setHidePlayButton]: [boolean, (x: boolean) => void] =
         useState<boolean>(false);
-    const [isPlayingAudio, setIsPlayingAudio] = useState(true);
+    const [isPlayingAudio, setIsPlayingAudio] = useState(false);
     const onResize = useCallback((width, height) => {
         const goban = goban_ref.current;
         if (goban) {
@@ -102,7 +102,7 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
 
     useEffect(() => {
         console.log("Constructing game ", chapter, page);
-        const content = new chapters[chapter][page]();
+        const content = new chapters[chapter][page](isPlayingAudio);
 
         if (audioRef.current) {
             audioRef.current.src = content.audioUrl;

--- a/src/views/Lessons/Lesson.tsx
+++ b/src/views/Lessons/Lesson.tsx
@@ -266,7 +266,6 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
             goban_opts_ref.current = null;
             clearTimeout(animation_interval);
             hup(Math.random());
-            // Stop and reset audio
             if (audioRef.current) {
                 audioRef.current.pause();
                 audioRef.current.currentTime = 0;
@@ -285,8 +284,6 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
             setIsPlayingAudio(!isPlayingAudio);
         }
     };
-
-    console.log("isPlayingAudio VALUE", isPlayingAudio);
 
     return (
         <>

--- a/src/views/Lessons/Lesson.tsx
+++ b/src/views/Lessons/Lesson.tsx
@@ -77,7 +77,7 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
     const [showAxotol, setShowAxotol]: [boolean, (x: boolean) => void] = useState<boolean>(false);
     const [hidePlayButton, setHidePlayButton]: [boolean, (x: boolean) => void] =
         useState<boolean>(false);
-    const [shouldPlayAudio, setShouldPlayAudio] = useState(true);
+    const [shouldPlayAudio, setShouldPlayAudio] = useState(true); // State for tracking audio on learn-to-play pages where it has audio matching the text, set to true initially, but can dynamically set it off localstorage if needed
     const onResize = useCallback((width, height) => {
         const goban = goban_ref.current;
         if (goban) {
@@ -104,6 +104,7 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
         console.log("Constructing game ", chapter, page);
         const content = new chapters[chapter][page](shouldPlayAudio);
 
+        // Playing audio that matches text on learn-to-play pages
         if (audioRef.current) {
             audioRef.current.src = content.audioUrl;
             if (shouldPlayAudio) {

--- a/src/views/Lessons/Lesson.tsx
+++ b/src/views/Lessons/Lesson.tsx
@@ -77,7 +77,7 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
     const [showAxotol, setShowAxotol]: [boolean, (x: boolean) => void] = useState<boolean>(false);
     const [hidePlayButton, setHidePlayButton]: [boolean, (x: boolean) => void] =
         useState<boolean>(false);
-    const [isPlayingAudio, setIsPlayingAudio] = useState(false);
+    const [shouldPlayAudio, setShouldPlayAudio] = useState(true);
     const onResize = useCallback((width, height) => {
         const goban = goban_ref.current;
         if (goban) {
@@ -102,11 +102,11 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
 
     useEffect(() => {
         console.log("Constructing game ", chapter, page);
-        const content = new chapters[chapter][page](isPlayingAudio);
+        const content = new chapters[chapter][page](shouldPlayAudio);
 
         if (audioRef.current) {
             audioRef.current.src = content.audioUrl;
-            if (isPlayingAudio) {
+            if (shouldPlayAudio) {
                 audioRef.current.play();
             }
         }
@@ -271,17 +271,17 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
                 audioRef.current.currentTime = 0;
             }
         };
-    }, [chapter, page, replay, isPlayingAudio]);
+    }, [chapter, page, replay]);
 
     const toggleAudio = () => {
         const audio = audioRef.current;
         if (audio) {
-            if (isPlayingAudio) {
+            if (shouldPlayAudio) {
                 audio.pause();
             } else {
                 audio.play();
             }
-            setIsPlayingAudio(!isPlayingAudio);
+            setShouldPlayAudio(!shouldPlayAudio);
         }
     };
 
@@ -295,7 +295,7 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
                     <div id="left-container">
                         <div className="explanation-text" onClick={cancel_animation_ref.current}>
                             <button onClick={toggleAudio}>
-                                {isPlayingAudio ? "Mute Audio" : "Play Audio"}
+                                {shouldPlayAudio ? "Mute Audio" : "Play Audio"}
                             </button>
                             <audio ref={audioRef} style={{ display: "none" }} />
                             {text}

--- a/src/views/Lessons/Lesson.tsx
+++ b/src/views/Lessons/Lesson.tsx
@@ -67,7 +67,7 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
     const [container, _setContainer] = useState(document.createElement("div"));
     const goban_ref = useRef<Goban>(null);
     const cancel_animation_ref = useRef<() => void>(() => {});
-    const audioRef = useRef<HTMLAudioElement>(null); // ADDED THIS
+    const audioRef = useRef<HTMLAudioElement>(null);
     const goban_opts_ref = useRef<any>({});
     const [text, setText]: [Array<JSX.Element>, (x: Array<JSX.Element>) => void] = useState<
         Array<JSX.Element>
@@ -77,7 +77,7 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
     const [showAxotol, setShowAxotol]: [boolean, (x: boolean) => void] = useState<boolean>(false);
     const [hidePlayButton, setHidePlayButton]: [boolean, (x: boolean) => void] =
         useState<boolean>(false);
-    const [isPlayingAudio, setIsPlayingAudio] = useState(true); // ADDED THIS -> audio starts off as true
+    const [isPlayingAudio, setIsPlayingAudio] = useState(true);
     const onResize = useCallback((width, height) => {
         const goban = goban_ref.current;
         if (goban) {
@@ -102,9 +102,8 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
 
     useEffect(() => {
         console.log("Constructing game ", chapter, page);
-        const content = new chapters[chapter][page]() as any;
+        const content = new chapters[chapter][page]();
 
-        // Set up audio
         if (audioRef.current) {
             audioRef.current.src = content.audioUrl;
             if (isPlayingAudio) {
@@ -120,7 +119,7 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
         const animation = content.animate(() => {
             setText(target_text.slice(0, ct++));
             return target_text.length >= ct;
-        }, 0); // Remove 500ms animation and replace with 0ms animation for text field in left panel since we have the audio now
+        }, 0); // Not working anymore (6/26/2024) -> Used to allow the value to animate the text showing up in the left panel, look in the return portion for original working code
         cancel_animation_ref.current = () => {
             animation.cancel();
             setText(target_text);
@@ -303,6 +302,7 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
                             </button>
                             <audio ref={audioRef} style={{ display: "none" }} />
                             {text}
+                            {/* Text animation logic below */}
                             {/* {text.map((e, idx) => (
                                 <div className="fade-in" key={idx}>
                                     {e}

--- a/src/views/Lessons/Lesson.tsx
+++ b/src/views/Lessons/Lesson.tsx
@@ -67,6 +67,7 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
     const [container, _setContainer] = useState(document.createElement("div"));
     const goban_ref = useRef<Goban>(null);
     const cancel_animation_ref = useRef<() => void>(() => {});
+    const audioRef = useRef<HTMLAudioElement>(null); // ADDED THIS
     const goban_opts_ref = useRef<any>({});
     const [text, setText]: [Array<JSX.Element>, (x: Array<JSX.Element>) => void] = useState<
         Array<JSX.Element>
@@ -76,6 +77,7 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
     const [showAxotol, setShowAxotol]: [boolean, (x: boolean) => void] = useState<boolean>(false);
     const [hidePlayButton, setHidePlayButton]: [boolean, (x: boolean) => void] =
         useState<boolean>(false);
+    const [isPlayingAudio, setIsPlayingAudio] = useState(true); // ADDED THIS -> audio starts off as true
     const onResize = useCallback((width, height) => {
         const goban = goban_ref.current;
         if (goban) {
@@ -101,6 +103,7 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
     useEffect(() => {
         console.log("Constructing game ", chapter, page);
         const content = new chapters[chapter][page]();
+        // const content = new chapters[chapter][page](audioRef);
 
         let ct = 0;
 
@@ -258,8 +261,35 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
             goban_opts_ref.current = null;
             clearTimeout(animation_interval);
             hup(Math.random());
+            // Stop and reset audio
+            if (audioRef.current) {
+                audioRef.current.pause();
+                audioRef.current.currentTime = 0;
+            }
         };
-    }, [chapter, page, replay]);
+    }, [chapter, page, replay, isPlayingAudio]);
+
+    const toggleAudio = async () => {
+        const audio = audioRef?.current;
+
+        if (isPlayingAudio) {
+            // console.log("hit here 1.");
+            // if (audio) {
+            //     console.log("hit here 2.");
+            //     console.log("audioRef.current 22222", audioRef.current);
+            //     audio.pause();
+            //     audio.currentTime = 0;
+            // }
+            setIsPlayingAudio(false);
+        } else {
+            // if (audio) {
+            //     await audio.play();
+            // }
+            setIsPlayingAudio(true);
+        }
+    };
+
+    console.log("isPlayingAudio VALUE", isPlayingAudio);
 
     return (
         <>
@@ -270,11 +300,26 @@ export function Lesson({ chapter, page }: { chapter: number; page: number }): JS
                 <div id="Lesson-bottom-container">
                     <div id="left-container">
                         <div className="explanation-text" onClick={cancel_animation_ref.current}>
-                            {text.map((e, idx) => (
+                            <button onClick={toggleAudio}>
+                                {isPlayingAudio ? "Stop Audio" : "Play Audio"}
+                            </button>
+                            {/* <audio
+                                key="audioElement"
+                                ref={audioRef}
+                                style={{ visibility: "hidden" }}
+                                autoPlay={true} // This line auto plays the audio when we click the next button to navigate to the next page
+                                // src={audioUrl}
+                            ></audio> */}
+                            {/* <audio
+                                ref={audioRef}
+                                style={{ visibility: "hidden" }}
+                            ></audio> */}
+                            {text}
+                            {/* {text.map((e, idx) => (
                                 <div className="fade-in" key={idx}>
                                     {e}
                                 </div>
-                            ))}
+                            ))} */}
                         </div>
                         <div className="bottom-graphic" />
                     </div>

--- a/src/views/Lessons/Module1.tsx
+++ b/src/views/Lessons/Module1.tsx
@@ -24,18 +24,20 @@ import { openPopup } from "PopupDialog";
 const POPUP_TIMEOUT = 3000;
 
 class Module1 extends Content {
-    constructor(audioUrl: string, shouldPlayAudio: boolean) {
+    constructor(audioUrl: string, shouldPlayAudio?: boolean) {
         super();
         this.audioUrl = audioUrl;
-        this.shouldPlayAudio = shouldPlayAudio;
+        // Make shouldPlayAudio optional, as only the puzzles need it for conditionally checking if we should render the audio when a user answers the puzzle right
+        if (shouldPlayAudio !== undefined) {
+            this.shouldPlayAudio = shouldPlayAudio;
+        }
     }
 }
 
 class Page1 extends Module1 {
-    constructor(shouldPlayAudio: boolean) {
+    constructor() {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472624/audio-slice-less-pauses-COMBINED/slice1_and_2_combined_wxolf5.mp3",
-            shouldPlayAudio,
         );
     }
 
@@ -64,10 +66,9 @@ class Page1 extends Module1 {
 }
 
 class Page2 extends Module1 {
-    constructor(shouldPlayAudio: boolean) {
+    constructor() {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472317/audio-slices-less-pauses/slice3_less_pauses_c9w9eo.mp3",
-            shouldPlayAudio,
         );
     }
 
@@ -99,10 +100,9 @@ class Page2 extends Module1 {
 }
 
 class Page3 extends Module1 {
-    constructor(shouldPlayAudio: boolean) {
+    constructor() {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472317/audio-slices-less-pauses/slice4_less_pauses_jiozem.mp3",
-            shouldPlayAudio,
         );
     }
 
@@ -130,10 +130,9 @@ class Page3 extends Module1 {
 }
 
 class Page4 extends Module1 {
-    constructor(shouldPlayAudio: boolean) {
+    constructor() {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472318/audio-slices-less-pauses/slice5_less_pauses_pebkdl.mp3",
-            shouldPlayAudio,
         );
     }
 
@@ -157,10 +156,9 @@ class Page4 extends Module1 {
 }
 
 class Page5 extends Module1 {
-    constructor(shouldPlayAudio: boolean) {
+    constructor() {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708473054/audio-slices-less-pauses/slice6_less_pauses_revised_zbk8aa.mp3",
-            shouldPlayAudio,
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -193,10 +191,9 @@ class Page5 extends Module1 {
 }
 
 class Page6 extends Module1 {
-    constructor(shouldPlayAudio: boolean) {
+    constructor() {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472320/audio-slices-less-pauses/slice7_less_pauses_nmppvy.mp3",
-            shouldPlayAudio,
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -225,10 +222,9 @@ class Page6 extends Module1 {
 }
 
 class Page7 extends Module1 {
-    constructor(shouldPlayAudio: boolean) {
+    constructor() {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708473412/audio-slice-less-pauses-COMBINED/slice8_and_9_combined_revised_fxjbn9.mp3",
-            shouldPlayAudio,
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -255,10 +251,9 @@ class Page7 extends Module1 {
 }
 
 class Page8 extends Module1 {
-    constructor(shouldPlayAudio: boolean) {
+    constructor() {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472323/audio-slices-less-pauses/slice10_less_pauses_o5h9dp.mp3",
-            shouldPlayAudio,
         );
     }
     text(): JSX.Element | Array<JSX.Element> {

--- a/src/views/Lessons/Module1.tsx
+++ b/src/views/Lessons/Module1.tsx
@@ -24,18 +24,18 @@ import { openPopup } from "PopupDialog";
 const POPUP_TIMEOUT = 3000;
 
 class Module1 extends Content {
-    constructor(audioUrl: string, isPlayingAudio: boolean) {
+    constructor(audioUrl: string, shouldPlayAudio: boolean) {
         super();
         this.audioUrl = audioUrl;
-        this.isPlayingAudio = isPlayingAudio;
+        this.shouldPlayAudio = shouldPlayAudio;
     }
 }
 
 class Page1 extends Module1 {
-    constructor(isPlayingAudio: boolean) {
+    constructor(shouldPlayAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472624/audio-slice-less-pauses-COMBINED/slice1_and_2_combined_wxolf5.mp3",
-            isPlayingAudio,
+            shouldPlayAudio,
         );
     }
 
@@ -64,10 +64,10 @@ class Page1 extends Module1 {
 }
 
 class Page2 extends Module1 {
-    constructor(isPlayingAudio: boolean) {
+    constructor(shouldPlayAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472317/audio-slices-less-pauses/slice3_less_pauses_c9w9eo.mp3",
-            isPlayingAudio,
+            shouldPlayAudio,
         );
     }
 
@@ -99,10 +99,10 @@ class Page2 extends Module1 {
 }
 
 class Page3 extends Module1 {
-    constructor(isPlayingAudio: boolean) {
+    constructor(shouldPlayAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472317/audio-slices-less-pauses/slice4_less_pauses_jiozem.mp3",
-            isPlayingAudio,
+            shouldPlayAudio,
         );
     }
 
@@ -130,10 +130,10 @@ class Page3 extends Module1 {
 }
 
 class Page4 extends Module1 {
-    constructor(isPlayingAudio: boolean) {
+    constructor(shouldPlayAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472318/audio-slices-less-pauses/slice5_less_pauses_pebkdl.mp3",
-            isPlayingAudio,
+            shouldPlayAudio,
         );
     }
 
@@ -157,10 +157,10 @@ class Page4 extends Module1 {
 }
 
 class Page5 extends Module1 {
-    constructor(isPlayingAudio: boolean) {
+    constructor(shouldPlayAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708473054/audio-slices-less-pauses/slice6_less_pauses_revised_zbk8aa.mp3",
-            isPlayingAudio,
+            shouldPlayAudio,
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -193,10 +193,10 @@ class Page5 extends Module1 {
 }
 
 class Page6 extends Module1 {
-    constructor(isPlayingAudio: boolean) {
+    constructor(shouldPlayAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472320/audio-slices-less-pauses/slice7_less_pauses_nmppvy.mp3",
-            isPlayingAudio,
+            shouldPlayAudio,
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -225,10 +225,10 @@ class Page6 extends Module1 {
 }
 
 class Page7 extends Module1 {
-    constructor(isPlayingAudio: boolean) {
+    constructor(shouldPlayAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708473412/audio-slice-less-pauses-COMBINED/slice8_and_9_combined_revised_fxjbn9.mp3",
-            isPlayingAudio,
+            shouldPlayAudio,
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -255,10 +255,10 @@ class Page7 extends Module1 {
 }
 
 class Page8 extends Module1 {
-    constructor(isPlayingAudio: boolean) {
+    constructor(shouldPlayAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472323/audio-slices-less-pauses/slice10_less_pauses_o5h9dp.mp3",
-            isPlayingAudio,
+            shouldPlayAudio,
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -288,10 +288,10 @@ class Page8 extends Module1 {
 class Puzzle1 extends Module1 {
     private successAudio: HTMLAudioElement;
 
-    constructor(isPlayingAudio: boolean) {
+    constructor(shouldPlayAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708547807/audio-slice-less-pauses-COMBINED/slice11_and_12_combined_dzwlo9.mp3",
-            isPlayingAudio,
+            shouldPlayAudio,
         );
         // Success audio for the popup audio!  Says "Good job!"
         this.successAudio = new Audio(
@@ -315,7 +315,7 @@ class Puzzle1 extends Module1 {
         goban.on("update", () => {
             if (goban.engine.board[0][3] === 0) {
                 // If we chain the success audio after the captureDelay, the "good job audio clip" happens after we go to the next puzzle
-                if (this.isPlayingAudio) {
+                if (this.shouldPlayAudio) {
                     this.successAudio
                         .play()
                         .catch((error) => console.error("Error playing success audio:", error));
@@ -339,10 +339,10 @@ class Puzzle1 extends Module1 {
 class Puzzle2 extends Module1 {
     private successAudio: HTMLAudioElement;
 
-    constructor(isPlayingAudio: boolean) {
+    constructor(shouldPlayAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472327/audio-slices-less-pauses/slice14_less_pauses_if00pt.mp3",
-            isPlayingAudio,
+            shouldPlayAudio,
         );
         this.successAudio = new Audio(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472328/audio-slices-less-pauses/slice15_less_pauses_w7g2jr.mp3",
@@ -362,7 +362,7 @@ class Puzzle2 extends Module1 {
     onSetGoban(goban: Goban): void {
         goban.on("update", () => {
             if (goban.engine.board[3][4] === 0) {
-                if (this.isPlayingAudio) {
+                if (this.shouldPlayAudio) {
                     this.successAudio
                         .play()
                         .catch((error) => console.error("Error playing success audio:", error));
@@ -385,10 +385,10 @@ class Puzzle2 extends Module1 {
 
 class Puzzle3 extends Module1 {
     private successAudio: HTMLAudioElement;
-    constructor(isPlayingAudio: boolean) {
+    constructor(shouldPlayAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472329/audio-slices-less-pauses/slice16_less_pauses_muc2vl.mp3",
-            isPlayingAudio,
+            shouldPlayAudio,
         );
         this.successAudio = new Audio(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472331/audio-slices-less-pauses/slice17_less_pauses_znln8h.mp3",
@@ -409,7 +409,7 @@ class Puzzle3 extends Module1 {
     onSetGoban(goban: Goban): void {
         goban.on("update", () => {
             if (goban.engine.board[3][4] === 0) {
-                if (this.isPlayingAudio) {
+                if (this.shouldPlayAudio) {
                     this.successAudio
                         .play()
                         .catch((error) => console.error("Error playing success audio:", error));
@@ -432,10 +432,10 @@ class Puzzle3 extends Module1 {
 
 class Puzzle4 extends Module1 {
     private successAudio: HTMLAudioElement;
-    constructor(isPlayingAudio: boolean) {
+    constructor(shouldPlayAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548582/audio-slices-less-pauses/slice18_less_pauses_revised_y2583y.mp3",
-            isPlayingAudio,
+            shouldPlayAudio,
         );
         this.successAudio = new Audio(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548659/audio-slices-less-pauses/slice19_less_pauses_revised_fykpjy.mp3",
@@ -456,7 +456,7 @@ class Puzzle4 extends Module1 {
     onSetGoban(goban: Goban): void {
         goban.on("update", () => {
             if (goban.engine.board[3][4] === 0) {
-                if (this.isPlayingAudio) {
+                if (this.shouldPlayAudio) {
                     this.successAudio
                         .play()
                         .catch((error) => console.error("Error playing success audio:", error));

--- a/src/views/Lessons/Module1.tsx
+++ b/src/views/Lessons/Module1.tsx
@@ -29,57 +29,41 @@ class Module1 extends Content {
     audioUrl: string;
 
     constructor(audioUrl: string) {
-        // constructor(audioUrl: string, audioRef: React.RefObject<HTMLAudioElement>) {
         super();
-        // super(audioRef);
-        this.audioRef = this.audioRef;
-        // this.audioRef = audioRef;
         this.audioUrl = audioUrl;
     }
 
-    playAudio = async () => {
-        const audio = this.audioRef.current;
-        if (audio) {
-            await audio.play();
-        }
-    };
+    // playAudio = async () => {
+    //     const audio = this.audioRef.current;
+    //     if (audio) {
+    //         await audio.play();
+    //     }
+    // };
 
-    componentWillUnmount() {
-        // Stop audio playback and cleanup when the component is about to unmount
-        const audio = this.audioRef.current;
-        if (audio) {
-            audio.pause();
-            audio.currentTime = 0;
-        }
-        // Clean up the delay of stone animations, otherwise it'll persist across rerenders and cause weird side effects
-        Object.keys(this.delays).forEach((key) => {
-            clearTimeout(this.delays[key]);
-            delete this.delays[key];
-        });
-    }
+    // componentWillUnmount() {
+    //     // Stop audio playback and cleanup when the component is about to unmount
+    //     const audio = this.audioRef.current;
+    //     if (audio) {
+    //         audio.pause();
+    //         audio.currentTime = 0;
+    //     }
+    //     // Clean up the delay of stone animations, otherwise it'll persist across rerenders and cause weird side effects
+    //     Object.keys(this.delays).forEach((key) => {
+    //         clearTimeout(this.delays[key]);
+    //         delete this.delays[key];
+    //     });
+    // }
 }
 
 class Page1 extends Module1 {
     constructor() {
-        // constructor(audioRef: React.RefObject<HTMLAudioElement>) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472624/audio-slice-less-pauses-COMBINED/slice1_and_2_combined_wxolf5.mp3",
-            // audioRef,
         );
     }
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            // <button key="playButton" onClick={this.playAudio}>
-            //     Play Audio
-            // </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true} // This line auto plays the audio when we click the next button to navigate to the next page
-                src={this.audioUrl}
-            ></audio>,
             <p>In Go we place stones on the lines, not in the squares!</p>,
             <p>
                 The darker color, Blast Off Blue in this case, always goes first, followed by the
@@ -111,16 +95,16 @@ class Page2 extends Module1 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
+            // <button key="playButton" onClick={this.playAudio}>
+            //     Play Audio
+            // </button>,
+            // <audio
+            //     key="audioElement"
+            //     ref={this.audioRef}
+            //     style={{ visibility: "hidden" }}
+            //     autoPlay={true}
+            //     src={this.audioUrl}
+            // ></audio>,
             <p>
                 The spaces next to the stones are important, we call them Liberties. This stone has
                 four liberties where the lines cross.
@@ -155,16 +139,16 @@ class Page3 extends Module1 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
+            // <button key="playButton" onClick={this.playAudio}>
+            //     Play Audio
+            // </button>,
+            // <audio
+            //     key="audioElement"
+            //     ref={this.audioRef}
+            //     style={{ visibility: "hidden" }}
+            //     autoPlay={true}
+            //     src={this.audioUrl}
+            // ></audio>,
             <p>
                 There are no liberties off the edge of the board, so this stone only has two
                 liberties.
@@ -195,16 +179,16 @@ class Page4 extends Module1 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
+            // <button key="playButton" onClick={this.playAudio}>
+            //     Play Audio
+            // </button>,
+            // <audio
+            //     key="audioElement"
+            //     ref={this.audioRef}
+            //     style={{ visibility: "hidden" }}
+            //     autoPlay={true}
+            //     src={this.audioUrl}
+            // ></audio>,
             <p>And this stone only has three.</p>,
         ];
     }
@@ -232,16 +216,16 @@ class Page5 extends Module1 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
+            // <button key="playButton" onClick={this.playAudio}>
+            //     Play Audio
+            // </button>,
+            // <audio
+            //     key="audioElement"
+            //     ref={this.audioRef}
+            //     style={{ visibility: "hidden" }}
+            //     autoPlay={true}
+            //     src={this.audioUrl}
+            // ></audio>,
             <p>
                 Stones of the same color that touch each other are on the same team. So they share
                 their liberties.
@@ -277,16 +261,16 @@ class Page6 extends Module1 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
+            // <button key="playButton" onClick={this.playAudio}>
+            //     Play Audio
+            // </button>,
+            // <audio
+            //     key="audioElement"
+            //     ref={this.audioRef}
+            //     style={{ visibility: "hidden" }}
+            //     autoPlay={true}
+            //     src={this.audioUrl}
+            // ></audio>,
             <p>
                 If the other player takes 3 out of 4 liberties, we say a stone is in Atari, which
                 means it can be captured on the next turn.
@@ -318,16 +302,16 @@ class Page7 extends Module1 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
+            // <button key="playButton" onClick={this.playAudio}>
+            //     Play Audio
+            // </button>,
+            // <audio
+            //     key="audioElement"
+            //     ref={this.audioRef}
+            //     style={{ visibility: "hidden" }}
+            //     autoPlay={true}
+            //     src={this.audioUrl}
+            // ></audio>,
             <p>If we add a stone, then they form a team and get new liberties.</p>,
             <p>Now they have three liberties and are safe from immediate capture.</p>,
         ];
@@ -357,16 +341,16 @@ class Page8 extends Module1 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
+            // <button key="playButton" onClick={this.playAudio}>
+            //     Play Audio
+            // </button>,
+            // <audio
+            //     key="audioElement"
+            //     ref={this.audioRef}
+            //     style={{ visibility: "hidden" }}
+            //     autoPlay={true}
+            //     src={this.audioUrl}
+            // ></audio>,
             <p>
                 If Blue goes somewhere else though, then White can capture the stone and remove it
                 from the board.
@@ -405,16 +389,16 @@ class Puzzle1 extends Module1 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
+            // <button key="playButton" onClick={this.playAudio}>
+            //     Play Audio
+            // </button>,
+            // <audio
+            //     key="audioElement"
+            //     ref={this.audioRef}
+            //     style={{ visibility: "hidden" }}
+            //     autoPlay={true}
+            //     src={this.audioUrl}
+            // ></audio>,
             <p>Lets try some simple problems now. Try and capture the White stone.</p>,
         ];
     }
@@ -462,16 +446,16 @@ class Puzzle2 extends Module1 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
+            // <button key="playButton" onClick={this.playAudio}>
+            //     Play Audio
+            // </button>,
+            // <audio
+            //     key="audioElement"
+            //     ref={this.audioRef}
+            //     style={{ visibility: "hidden" }}
+            //     autoPlay={true}
+            //     src={this.audioUrl}
+            // ></audio>,
             <p>Try and capture the White stone.</p>,
         ];
     }
@@ -517,16 +501,16 @@ class Puzzle3 extends Module1 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
+            // <button key="playButton" onClick={this.playAudio}>
+            //     Play Audio
+            // </button>,
+            // <audio
+            //     key="audioElement"
+            //     ref={this.audioRef}
+            //     style={{ visibility: "hidden" }}
+            //     autoPlay={true}
+            //     src={this.audioUrl}
+            // ></audio>,
             <p>Try and capture the White stones.</p>,
         ];
     }
@@ -573,16 +557,16 @@ class Puzzle4 extends Module1 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
+            // <button key="playButton" onClick={this.playAudio}>
+            //     Play Audio
+            // </button>,
+            // <audio
+            //     key="audioElement"
+            //     ref={this.audioRef}
+            //     style={{ visibility: "hidden" }}
+            //     autoPlay={true}
+            //     src={this.audioUrl}
+            // ></audio>,
             <p>Try and capture these White stones.</p>,
         ];
     }

--- a/src/views/Lessons/Module1.tsx
+++ b/src/views/Lessons/Module1.tsx
@@ -24,35 +24,10 @@ import { openPopup } from "PopupDialog";
 const POPUP_TIMEOUT = 3000;
 
 class Module1 extends Content {
-    audioRef: React.RefObject<HTMLAudioElement>;
-    // audioRef: React.RefObject<HTMLAudioElement>;
-    audioUrl: string;
-
     constructor(audioUrl: string) {
         super();
         this.audioUrl = audioUrl;
     }
-
-    // playAudio = async () => {
-    //     const audio = this.audioRef.current;
-    //     if (audio) {
-    //         await audio.play();
-    //     }
-    // };
-
-    // componentWillUnmount() {
-    //     // Stop audio playback and cleanup when the component is about to unmount
-    //     const audio = this.audioRef.current;
-    //     if (audio) {
-    //         audio.pause();
-    //         audio.currentTime = 0;
-    //     }
-    //     // Clean up the delay of stone animations, otherwise it'll persist across rerenders and cause weird side effects
-    //     Object.keys(this.delays).forEach((key) => {
-    //         clearTimeout(this.delays[key]);
-    //         delete this.delays[key];
-    //     });
-    // }
 }
 
 class Page1 extends Module1 {
@@ -95,16 +70,6 @@ class Page2 extends Module1 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            // <button key="playButton" onClick={this.playAudio}>
-            //     Play Audio
-            // </button>,
-            // <audio
-            //     key="audioElement"
-            //     ref={this.audioRef}
-            //     style={{ visibility: "hidden" }}
-            //     autoPlay={true}
-            //     src={this.audioUrl}
-            // ></audio>,
             <p>
                 The spaces next to the stones are important, we call them Liberties. This stone has
                 four liberties where the lines cross.
@@ -139,16 +104,6 @@ class Page3 extends Module1 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            // <button key="playButton" onClick={this.playAudio}>
-            //     Play Audio
-            // </button>,
-            // <audio
-            //     key="audioElement"
-            //     ref={this.audioRef}
-            //     style={{ visibility: "hidden" }}
-            //     autoPlay={true}
-            //     src={this.audioUrl}
-            // ></audio>,
             <p>
                 There are no liberties off the edge of the board, so this stone only has two
                 liberties.
@@ -178,19 +133,7 @@ class Page4 extends Module1 {
     }
 
     text(): JSX.Element | Array<JSX.Element> {
-        return [
-            // <button key="playButton" onClick={this.playAudio}>
-            //     Play Audio
-            // </button>,
-            // <audio
-            //     key="audioElement"
-            //     ref={this.audioRef}
-            //     style={{ visibility: "hidden" }}
-            //     autoPlay={true}
-            //     src={this.audioUrl}
-            // ></audio>,
-            <p>And this stone only has three.</p>,
-        ];
+        return [<p>And this stone only has three.</p>];
     }
     config(): PuzzleConfig {
         return {
@@ -216,16 +159,6 @@ class Page5 extends Module1 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            // <button key="playButton" onClick={this.playAudio}>
-            //     Play Audio
-            // </button>,
-            // <audio
-            //     key="audioElement"
-            //     ref={this.audioRef}
-            //     style={{ visibility: "hidden" }}
-            //     autoPlay={true}
-            //     src={this.audioUrl}
-            // ></audio>,
             <p>
                 Stones of the same color that touch each other are on the same team. So they share
                 their liberties.
@@ -261,16 +194,6 @@ class Page6 extends Module1 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            // <button key="playButton" onClick={this.playAudio}>
-            //     Play Audio
-            // </button>,
-            // <audio
-            //     key="audioElement"
-            //     ref={this.audioRef}
-            //     style={{ visibility: "hidden" }}
-            //     autoPlay={true}
-            //     src={this.audioUrl}
-            // ></audio>,
             <p>
                 If the other player takes 3 out of 4 liberties, we say a stone is in Atari, which
                 means it can be captured on the next turn.
@@ -302,16 +225,6 @@ class Page7 extends Module1 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            // <button key="playButton" onClick={this.playAudio}>
-            //     Play Audio
-            // </button>,
-            // <audio
-            //     key="audioElement"
-            //     ref={this.audioRef}
-            //     style={{ visibility: "hidden" }}
-            //     autoPlay={true}
-            //     src={this.audioUrl}
-            // ></audio>,
             <p>If we add a stone, then they form a team and get new liberties.</p>,
             <p>Now they have three liberties and are safe from immediate capture.</p>,
         ];
@@ -341,16 +254,6 @@ class Page8 extends Module1 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            // <button key="playButton" onClick={this.playAudio}>
-            //     Play Audio
-            // </button>,
-            // <audio
-            //     key="audioElement"
-            //     ref={this.audioRef}
-            //     style={{ visibility: "hidden" }}
-            //     autoPlay={true}
-            //     src={this.audioUrl}
-            // ></audio>,
             <p>
                 If Blue goes somewhere else though, then White can capture the stone and remove it
                 from the board.
@@ -388,19 +291,7 @@ class Puzzle1 extends Module1 {
     }
 
     text(): JSX.Element | Array<JSX.Element> {
-        return [
-            // <button key="playButton" onClick={this.playAudio}>
-            //     Play Audio
-            // </button>,
-            // <audio
-            //     key="audioElement"
-            //     ref={this.audioRef}
-            //     style={{ visibility: "hidden" }}
-            //     autoPlay={true}
-            //     src={this.audioUrl}
-            // ></audio>,
-            <p>Lets try some simple problems now. Try and capture the White stone.</p>,
-        ];
+        return [<p>Lets try some simple problems now. Try and capture the White stone.</p>];
     }
     config(): PuzzleConfig {
         return {
@@ -445,19 +336,7 @@ class Puzzle2 extends Module1 {
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
-        return [
-            // <button key="playButton" onClick={this.playAudio}>
-            //     Play Audio
-            // </button>,
-            // <audio
-            //     key="audioElement"
-            //     ref={this.audioRef}
-            //     style={{ visibility: "hidden" }}
-            //     autoPlay={true}
-            //     src={this.audioUrl}
-            // ></audio>,
-            <p>Try and capture the White stone.</p>,
-        ];
+        return [<p>Try and capture the White stone.</p>];
     }
     config(): PuzzleConfig {
         return {
@@ -500,19 +379,7 @@ class Puzzle3 extends Module1 {
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
-        return [
-            // <button key="playButton" onClick={this.playAudio}>
-            //     Play Audio
-            // </button>,
-            // <audio
-            //     key="audioElement"
-            //     ref={this.audioRef}
-            //     style={{ visibility: "hidden" }}
-            //     autoPlay={true}
-            //     src={this.audioUrl}
-            // ></audio>,
-            <p>Try and capture the White stones.</p>,
-        ];
+        return [<p>Try and capture the White stones.</p>];
     }
     config(): PuzzleConfig {
         return {
@@ -556,19 +423,7 @@ class Puzzle4 extends Module1 {
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
-        return [
-            // <button key="playButton" onClick={this.playAudio}>
-            //     Play Audio
-            // </button>,
-            // <audio
-            //     key="audioElement"
-            //     ref={this.audioRef}
-            //     style={{ visibility: "hidden" }}
-            //     autoPlay={true}
-            //     src={this.audioUrl}
-            // ></audio>,
-            <p>Try and capture these White stones.</p>,
-        ];
+        return [<p>Try and capture these White stones.</p>];
     }
     config(): PuzzleConfig {
         return {

--- a/src/views/Lessons/Module1.tsx
+++ b/src/views/Lessons/Module1.tsx
@@ -25,11 +25,15 @@ const POPUP_TIMEOUT = 3000;
 
 class Module1 extends Content {
     audioRef: React.RefObject<HTMLAudioElement>;
+    // audioRef: React.RefObject<HTMLAudioElement>;
     audioUrl: string;
 
     constructor(audioUrl: string) {
+        // constructor(audioUrl: string, audioRef: React.RefObject<HTMLAudioElement>) {
         super();
-        this.audioRef = React.createRef();
+        // super(audioRef);
+        this.audioRef = this.audioRef;
+        // this.audioRef = audioRef;
         this.audioUrl = audioUrl;
     }
 
@@ -57,16 +61,18 @@ class Module1 extends Content {
 
 class Page1 extends Module1 {
     constructor() {
+        // constructor(audioRef: React.RefObject<HTMLAudioElement>) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472624/audio-slice-less-pauses-COMBINED/slice1_and_2_combined_wxolf5.mp3",
+            // audioRef,
         );
     }
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
+            // <button key="playButton" onClick={this.playAudio}>
+            //     Play Audio
+            // </button>,
             <audio
                 key="audioElement"
                 ref={this.audioRef}

--- a/src/views/Lessons/Module1.tsx
+++ b/src/views/Lessons/Module1.tsx
@@ -24,16 +24,18 @@ import { openPopup } from "PopupDialog";
 const POPUP_TIMEOUT = 3000;
 
 class Module1 extends Content {
-    constructor(audioUrl: string) {
+    constructor(audioUrl: string, isPlayingAudio: boolean) {
         super();
         this.audioUrl = audioUrl;
+        this.isPlayingAudio = isPlayingAudio;
     }
 }
 
 class Page1 extends Module1 {
-    constructor() {
+    constructor(isPlayingAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472624/audio-slice-less-pauses-COMBINED/slice1_and_2_combined_wxolf5.mp3",
+            isPlayingAudio,
         );
     }
 
@@ -62,9 +64,10 @@ class Page1 extends Module1 {
 }
 
 class Page2 extends Module1 {
-    constructor() {
+    constructor(isPlayingAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472317/audio-slices-less-pauses/slice3_less_pauses_c9w9eo.mp3",
+            isPlayingAudio,
         );
     }
 
@@ -96,9 +99,10 @@ class Page2 extends Module1 {
 }
 
 class Page3 extends Module1 {
-    constructor() {
+    constructor(isPlayingAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472317/audio-slices-less-pauses/slice4_less_pauses_jiozem.mp3",
+            isPlayingAudio,
         );
     }
 
@@ -126,9 +130,10 @@ class Page3 extends Module1 {
 }
 
 class Page4 extends Module1 {
-    constructor() {
+    constructor(isPlayingAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472318/audio-slices-less-pauses/slice5_less_pauses_pebkdl.mp3",
+            isPlayingAudio,
         );
     }
 
@@ -152,9 +157,10 @@ class Page4 extends Module1 {
 }
 
 class Page5 extends Module1 {
-    constructor() {
+    constructor(isPlayingAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708473054/audio-slices-less-pauses/slice6_less_pauses_revised_zbk8aa.mp3",
+            isPlayingAudio,
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -187,9 +193,10 @@ class Page5 extends Module1 {
 }
 
 class Page6 extends Module1 {
-    constructor() {
+    constructor(isPlayingAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472320/audio-slices-less-pauses/slice7_less_pauses_nmppvy.mp3",
+            isPlayingAudio,
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -218,9 +225,10 @@ class Page6 extends Module1 {
 }
 
 class Page7 extends Module1 {
-    constructor() {
+    constructor(isPlayingAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708473412/audio-slice-less-pauses-COMBINED/slice8_and_9_combined_revised_fxjbn9.mp3",
+            isPlayingAudio,
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -247,9 +255,10 @@ class Page7 extends Module1 {
 }
 
 class Page8 extends Module1 {
-    constructor() {
+    constructor(isPlayingAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472323/audio-slices-less-pauses/slice10_less_pauses_o5h9dp.mp3",
+            isPlayingAudio,
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -279,10 +288,10 @@ class Page8 extends Module1 {
 class Puzzle1 extends Module1 {
     private successAudio: HTMLAudioElement;
 
-    constructor() {
-        // This is the manually sliced audio clip for the first puzzle
+    constructor(isPlayingAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708547807/audio-slice-less-pauses-COMBINED/slice11_and_12_combined_dzwlo9.mp3",
+            isPlayingAudio,
         );
         // Success audio for the popup audio!  Says "Good job!"
         this.successAudio = new Audio(
@@ -306,9 +315,11 @@ class Puzzle1 extends Module1 {
         goban.on("update", () => {
             if (goban.engine.board[0][3] === 0) {
                 // If we chain the success audio after the captureDelay, the "good job audio clip" happens after we go to the next puzzle
-                this.successAudio
-                    .play()
-                    .catch((error) => console.error("Error playing success audio:", error));
+                if (this.isPlayingAudio) {
+                    this.successAudio
+                        .play()
+                        .catch((error) => console.error("Error playing success audio:", error));
+                }
                 this.captureDelay(() => {
                     openPopup({
                         text: <Axol>Good job!</Axol>,
@@ -327,9 +338,11 @@ class Puzzle1 extends Module1 {
 
 class Puzzle2 extends Module1 {
     private successAudio: HTMLAudioElement;
-    constructor() {
+
+    constructor(isPlayingAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472327/audio-slices-less-pauses/slice14_less_pauses_if00pt.mp3",
+            isPlayingAudio,
         );
         this.successAudio = new Audio(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472328/audio-slices-less-pauses/slice15_less_pauses_w7g2jr.mp3",
@@ -349,9 +362,11 @@ class Puzzle2 extends Module1 {
     onSetGoban(goban: Goban): void {
         goban.on("update", () => {
             if (goban.engine.board[3][4] === 0) {
-                this.successAudio
-                    .play()
-                    .catch((error) => console.error("Error playing success audio:", error));
+                if (this.isPlayingAudio) {
+                    this.successAudio
+                        .play()
+                        .catch((error) => console.error("Error playing success audio:", error));
+                }
                 this.captureDelay(() => {
                     openPopup({
                         text: <Axol>You did it!</Axol>,
@@ -370,9 +385,10 @@ class Puzzle2 extends Module1 {
 
 class Puzzle3 extends Module1 {
     private successAudio: HTMLAudioElement;
-    constructor() {
+    constructor(isPlayingAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472329/audio-slices-less-pauses/slice16_less_pauses_muc2vl.mp3",
+            isPlayingAudio,
         );
         this.successAudio = new Audio(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472331/audio-slices-less-pauses/slice17_less_pauses_znln8h.mp3",
@@ -393,9 +409,11 @@ class Puzzle3 extends Module1 {
     onSetGoban(goban: Goban): void {
         goban.on("update", () => {
             if (goban.engine.board[3][4] === 0) {
-                this.successAudio
-                    .play()
-                    .catch((error) => console.error("Error playing success audio:", error));
+                if (this.isPlayingAudio) {
+                    this.successAudio
+                        .play()
+                        .catch((error) => console.error("Error playing success audio:", error));
+                }
                 this.captureDelay(() => {
                     openPopup({
                         text: <Axol>Nice work!</Axol>,
@@ -414,9 +432,10 @@ class Puzzle3 extends Module1 {
 
 class Puzzle4 extends Module1 {
     private successAudio: HTMLAudioElement;
-    constructor() {
+    constructor(isPlayingAudio: boolean) {
         super(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548582/audio-slices-less-pauses/slice18_less_pauses_revised_y2583y.mp3",
+            isPlayingAudio,
         );
         this.successAudio = new Audio(
             "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548659/audio-slices-less-pauses/slice19_less_pauses_revised_fykpjy.mp3",
@@ -437,9 +456,11 @@ class Puzzle4 extends Module1 {
     onSetGoban(goban: Goban): void {
         goban.on("update", () => {
             if (goban.engine.board[3][4] === 0) {
-                this.successAudio
-                    .play()
-                    .catch((error) => console.error("Error playing success audio:", error));
+                if (this.isPlayingAudio) {
+                    this.successAudio
+                        .play()
+                        .catch((error) => console.error("Error playing success audio:", error));
+                }
                 this.captureDelay(() => {
                     openPopup({
                         text: <Axol>Very clever!</Axol>,

--- a/src/views/Lessons/Module2.tsx
+++ b/src/views/Lessons/Module2.tsx
@@ -20,7 +20,6 @@ import { Content } from "./Content";
 import { PuzzleConfig, Goban, JGOFNumericPlayerColor } from "goban";
 
 class Module2 extends Content {
-
     constructor(audioUrl: string) {
         super();
         this.audioUrl = audioUrl;
@@ -35,7 +34,7 @@ class Page1 extends Module2 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <span>
+            <span style={{ display: "block" }}>
                 Based on the last lesson you might think the goal of this game is to capture stones,
                 but actually whoever surrounds the most territory at the end of the game wins.
             </span>,
@@ -117,9 +116,7 @@ class Page4 extends Module2 {
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
-        return [
-            <p>Four points is right.</p>,
-        ];
+        return [<p>Four points is right.</p>];
     }
     config(): PuzzleConfig {
         return {
@@ -145,9 +142,7 @@ class Page5 extends Module2 {
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
-        return [
-            <p>How many points does Blue have here?</p>,
-        ];
+        return [<p>How many points does Blue have here?</p>];
     }
     config(): PuzzleConfig {
         return {
@@ -328,9 +323,7 @@ class Page11 extends Module2 {
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
-        return [
-            <p>And White has 24, so White is ahead by one.</p>,
-        ];
+        return [<p>And White has 24, so White is ahead by one.</p>];
     }
     config(): PuzzleConfig {
         return {

--- a/src/views/Lessons/Module2.tsx
+++ b/src/views/Lessons/Module2.tsx
@@ -20,28 +20,10 @@ import { Content } from "./Content";
 import { PuzzleConfig, Goban, JGOFNumericPlayerColor } from "goban";
 
 class Module2 extends Content {
-    audioRef: React.RefObject<HTMLAudioElement>;
-    audioUrl: string;
 
     constructor(audioUrl: string) {
         super();
-        this.audioRef = React.createRef();
         this.audioUrl = audioUrl;
-    }
-
-    playAudio = async () => {
-        const audio = this.audioRef.current;
-        if (audio) {
-            await audio.play();
-        }
-    };
-
-    componentWillUnmount() {
-        const audio = this.audioRef.current;
-        if (audio) {
-            audio.pause();
-            audio.currentTime = 0;
-        }
     }
 }
 
@@ -53,16 +35,6 @@ class Page1 extends Module2 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <span>
                 Based on the last lesson you might think the goal of this game is to capture stones,
                 but actually whoever surrounds the most territory at the end of the game wins.
@@ -88,16 +60,6 @@ class Page2 extends Module2 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 Territory is the empty space we surround. Here is one kind of territory using the
                 edge of the board. There are four points of territory in the corner.
@@ -131,16 +93,6 @@ class Page3 extends Module2 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 Here is another kind of territory, made by surrounding space in the middle. How many
                 points of territory does Blue have here?
@@ -166,16 +118,6 @@ class Page4 extends Module2 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>Four points is right.</p>,
         ];
     }
@@ -204,16 +146,6 @@ class Page5 extends Module2 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>How many points does Blue have here?</p>,
         ];
     }
@@ -238,16 +170,6 @@ class Page6 extends Module2 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>The answer is 9 points for Blue.</p>,
             <p>Remember, you only need to build your fence up to the edge of the board. </p>,
         ];
@@ -284,16 +206,6 @@ class Page7 extends Module2 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 In Go, we play until the two colors are touching each other, and the empty space
                 each blocks off and surrounds is their territory.
@@ -321,16 +233,6 @@ class Page8 extends Module2 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>Can White play on Blue's side? Yes.</p>,
             <p>Can Blue play on White's side? Yes.</p>,
             <p>
@@ -368,16 +270,6 @@ class Page9 extends Module2 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 If you think the game is over, just pass a stone to your opponent. If your opponent
                 plays a stone then you can either play or pass.
@@ -409,16 +301,6 @@ class Page10 extends Module2 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>Blue has territory on the left, and White has it on the right.</p>,
             <p>We can see Blue has 23 points.</p>,
         ];
@@ -447,16 +329,6 @@ class Page11 extends Module2 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>And White has 24, so White is ahead by one.</p>,
         ];
     }
@@ -484,16 +356,6 @@ class Page12 extends Module2 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>But Blue also captured three stones which went into the prisoner bowl.</p>,
             <p>Those three stones that Blue captured are subtracted from White's territory.</p>,
             <p>Now the score is Blue 23 and White 21 so Blue wins by two.</p>,
@@ -524,16 +386,6 @@ class Page13 extends Module2 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 When we play face-to-face we put all captures back into the territory of the same
                 color. So at the end of the game, the board will have all the stones played during
@@ -558,16 +410,6 @@ class Page14 extends Module2 {
     text(): JSX.Element | Array<JSX.Element> {
         return [
             // Audio not matching, need to record "and then come back to read the rest of these lessons."
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 You now know enough to play your first game of Go! There are actually two more
                 rules, but it can be confusing at first. Play a couple of games against the Easy

--- a/src/views/Lessons/Module3.tsx
+++ b/src/views/Lessons/Module3.tsx
@@ -22,28 +22,9 @@ import { openPopup } from "PopupDialog";
 import { Axol } from "./Axol";
 
 class Module3 extends Content {
-    audioRef: React.RefObject<HTMLAudioElement>;
-    audioUrl: string;
-
     constructor(audioUrl: string) {
         super();
-        this.audioRef = React.createRef();
         this.audioUrl = audioUrl;
-    }
-
-    playAudio = async () => {
-        const audio = this.audioRef.current;
-        if (audio) {
-            await audio.play();
-        }
-    };
-
-    componentWillUnmount() {
-        const audio = this.audioRef.current;
-        if (audio) {
-            audio.pause();
-            audio.currentTime = 0;
-        }
     }
 }
 
@@ -56,16 +37,6 @@ class Page1 extends Module3 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 One of the few rules in Go is that any stone played must have at least one liberty
                 after it's played.
@@ -99,16 +70,6 @@ class Page2 extends Module3 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 Now notice that this group has been completely closed in on the outside, although it
                 does still have liberties inside.
@@ -135,16 +96,6 @@ class Page3 extends Module3 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 If it's Blue's turn, a play in the middle will create a group with two separate
                 liberties inside. These are called eyes, and this group has two of them.
@@ -174,16 +125,6 @@ class Page4 extends Module3 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 White cannot play at either of the triangled points here, so Blue can never come
                 into atari. A group like this can not be captured because it has two eyes.
@@ -212,19 +153,7 @@ class Page5 extends Module3 {
     }
 
     text(): JSX.Element | Array<JSX.Element> {
-        return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
-            <p>What happens if White gets to play in the middle first?</p>,
-        ];
+        return [<p>What happens if White gets to play in the middle first?</p>];
     }
     config(): PuzzleConfig {
         return {
@@ -249,16 +178,6 @@ class Page6 extends Module3 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 If Blue tries to capture the stone by playing at 2, notice that all the blue stones
                 are now in atari at A.
@@ -293,16 +212,6 @@ class Page7 extends Module3 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>It looks like White can't play at A because the team would have no liberties.</p>,
             <p>But playing at A captures six Blue stones first giving White three liberties.</p>,
             <p>Remember, any stone played must have liberties at the end of the turn.</p>,
@@ -339,16 +248,6 @@ class Page8 extends Module3 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 So a Blue play at A is obviously not a good move. It takes one of Blue's liberties.
                 And playing at B would also put Blue's group into atari.
@@ -379,16 +278,6 @@ class Page9 extends Module3 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 So perhaps Blue decides not to play at either point. The group is not in atari, so
                 what can White do anyway? Well, White can play at 1...
@@ -421,16 +310,6 @@ class Page10 extends Module3 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 Now Blue is again in atari, and White could capture by playing at A. But wait, White
                 is in atari too...
@@ -459,19 +338,7 @@ class Page11 extends Module3 {
     }
 
     text(): JSX.Element | Array<JSX.Element> {
-        return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
-            <p>So Blue can capture two stones with 1. Surely the group is okay now.</p>,
-        ];
+        return [<p>So Blue can capture two stones with 1. Surely the group is okay now.</p>];
     }
     config(): PuzzleConfig {
         return {
@@ -501,16 +368,6 @@ class Page12 extends Module3 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 What happens if White plays at 2? It's true, White is also in atari, so Blue can
                 capture again...
@@ -553,16 +410,6 @@ class Page13 extends Module3 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 But now the Blue group only has a single liberty, which means White can capture
                 seven stones at once. Ouch!
@@ -596,16 +443,6 @@ class Page14 extends Module3 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 Looking again, we see that the placement of a single stone can make all the
                 difference. Playing at A is the key point for both sides.
@@ -634,19 +471,7 @@ class Page15 extends Module3 {
     }
 
     text(): JSX.Element | Array<JSX.Element> {
-        return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
-            <p>Good job learning about eyes so far, this is tricky stuff!</p>,
-        ];
+        return [<p>Good job learning about eyes so far, this is tricky stuff!</p>];
     }
     axolotlFace() {
         return true;

--- a/src/views/Lessons/Module4.tsx
+++ b/src/views/Lessons/Module4.tsx
@@ -21,28 +21,9 @@ import { PuzzleConfig, Goban, JGOFNumericPlayerColor } from "goban";
 import { openPopup } from "PopupDialog";
 
 class Module4 extends Content {
-    audioRef: React.RefObject<HTMLAudioElement>;
-    audioUrl: string;
-
     constructor(audioUrl: string) {
         super();
-        this.audioRef = React.createRef();
         this.audioUrl = audioUrl;
-    }
-
-    playAudio = async () => {
-        const audio = this.audioRef.current;
-        if (audio) {
-            await audio.play();
-        }
-    };
-
-    componentWillUnmount() {
-        const audio = this.audioRef.current;
-        if (audio) {
-            audio.pause();
-            audio.currentTime = 0;
-        }
     }
 }
 
@@ -55,16 +36,6 @@ class Page1 extends Module4 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 Here's a situation that sometimes comes up. Notice that the White stone at A is in
                 atari?
@@ -94,16 +65,6 @@ class Page2 extends Module4 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>Since Blue is capturing a stone and getting a liberty, playing at B is allowed.</p>,
             <p>But now Blue is in atari...</p>,
         ];
@@ -131,16 +92,6 @@ class Page3 extends Module4 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>So White could play at A again and capture Blue. But now White is in atari...</p>,
         ];
     }
@@ -167,16 +118,6 @@ class Page4 extends Module4 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>So Blue could capture, but then would be in atari again...</p>,
             <p>This could go on forever, so there is a special rule to cover it.</p>,
             <p>
@@ -208,16 +149,6 @@ class Page5 extends Module4 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 So the first player to capture in a position like this starts what is called a "ko".
                 On this board, Blue would start a ko by capturing at 1.
@@ -248,16 +179,6 @@ class Page6 extends Module4 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 The ko rule prevents a player from immediately recapturing. That would repeat the
                 board. But it only affects the first move after a capture.
@@ -288,16 +209,6 @@ class Page7 extends Module4 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 So White can play anywhere on the board except at the triangled point. Perhaps White
                 will play at 2, and then Blue might play at say, 3.
@@ -341,16 +252,6 @@ class Page8 extends Module4 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 Since the board has changed, a play at A is allowed. Now it’s Blue's turn to be
                 caught by the rule of ko. Blue can play anywhere except the triangled point.
@@ -383,16 +284,6 @@ class Page9 extends Module4 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>So perhaps Blue will play at 1 to connect two stones and prevent a cut by White.</p>,
         ];
     }
@@ -420,16 +311,6 @@ class Page10 extends Module4 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 If White thinks the ko is more important, it can be filled in with 2. In this case,
                 Blue actually gets a good solid position by playing at 3. So each side got
@@ -462,16 +343,6 @@ class Page11 extends Module4 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 Sometimes winning the ko can affect the life of a whole group. If Blue can capture
                 and then fill the ko at A, the group will make two eyes. If White wins, all the Blue
@@ -502,16 +373,6 @@ class Page12 extends Module4 {
 
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 Sometimes a ko is meaningless and only affects the stone in atari. Don't worry about
                 ko too much for right now, just start playing some games and you'll learn more as

--- a/src/views/Lessons/Module5.tsx
+++ b/src/views/Lessons/Module5.tsx
@@ -91,7 +91,7 @@ class Page3 extends Module5 {
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>Blue could add a stone at 2 to make a group with three liberties</p>];
+        return [<p>Blue could add a stone at 2 to make a group with three liberties.</p>];
     }
     config(): PuzzleConfig {
         return {

--- a/src/views/Lessons/Module5.tsx
+++ b/src/views/Lessons/Module5.tsx
@@ -21,28 +21,9 @@ import { PuzzleConfig, Goban, JGOFNumericPlayerColor } from "goban";
 import { openPopup } from "PopupDialog";
 
 class Module5 extends Content {
-    audioRef: React.RefObject<HTMLAudioElement>;
-    audioUrl: string;
-
     constructor(audioUrl: string) {
         super();
-        this.audioRef = React.createRef();
         this.audioUrl = audioUrl;
-    }
-
-    playAudio = async () => {
-        const audio = this.audioRef.current;
-        if (audio) {
-            await audio.play();
-        }
-    };
-
-    componentWillUnmount() {
-        const audio = this.audioRef.current;
-        if (audio) {
-            audio.pause();
-            audio.currentTime = 0;
-        }
     }
 }
 
@@ -54,16 +35,6 @@ class Page1 extends Module5 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>Here's an example of how some things might play out in a real game.</p>,
             <p>
                 Let's look at these two stones. They're not a team, because diagonal points are not
@@ -91,16 +62,6 @@ class Page2 extends Module5 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 With enough moves, both stones could be captured. The white stone at 1 places both
                 Blue stones into atari at once, or double atari.
@@ -130,19 +91,7 @@ class Page3 extends Module5 {
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
-        return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
-            <p>Blue could add a stone at 2 to make a group with three liberties</p>,
-        ];
+        return [<p>Blue could add a stone at 2 to make a group with three liberties</p>];
     }
     config(): PuzzleConfig {
         return {
@@ -176,16 +125,6 @@ class Page4 extends Module5 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 White can still capture the other stone at 3 though, because it's not connected to
                 the Blue group.
@@ -218,16 +157,6 @@ class Page5 extends Module5 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 So White might try to capture the Blue group by adding a stone at 1. Blue might try
                 playing at 2 to save the stones.
@@ -259,16 +188,6 @@ class Page6 extends Module5 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 Maybe White gets impatient and tries to surround Blue's group with 3. Blue responds
                 with 4, which puts White's stone at A into atari.
@@ -310,16 +229,6 @@ class Page7 extends Module5 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 White will lose the stone at A if Blue plays at B, so White adds a stone there to
                 get new liberties.
@@ -351,16 +260,6 @@ class Page8 extends Module5 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>Now Blue has turned the tables on white! Playing at 1 puts white C into atari.</p>,
         ];
     }
@@ -389,16 +288,6 @@ class Page9 extends Module5 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 White adds a stone at 2, but there's a problem. 2 is on the edge of the board, which
                 means there is one liberty less!
@@ -430,16 +319,6 @@ class Page10 extends Module5 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 This means that a move by Blue at either A or B will put two white stones into
                 atari. Which one do you think is best?
@@ -471,16 +350,6 @@ class Page11 extends Module5 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 Let's look at B first. This move looks good because on the next turn Blue could
                 capture the two white stones at A.
@@ -511,16 +380,6 @@ class Page12 extends Module5 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 Unfortunately, it's not Blue's turn. While it is true that white is in atari, Blue
                 is also now in atari, so white can capture first - at C - and remove four Blue
@@ -560,16 +419,6 @@ class Page13 extends Module5 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 Let's try going the other way this time. A Blue play at A also puts the two white
                 stones into atari.
@@ -599,19 +448,7 @@ class Page14 extends Module5 {
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
-        return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
-            <p>Now even if white adds a stone at 2, which puts Blue into atari at D...</p>,
-        ];
+        return [<p>Now even if white adds a stone at 2, which puts Blue into atari at D...</p>];
     }
     config(): PuzzleConfig {
         return {
@@ -638,19 +475,7 @@ class Page15 extends Module5 {
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
-        return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
-            <p>It's now Blue's turn, and playing at D captures all three white stones.</p>,
-        ];
+        return [<p>It's now Blue's turn, and playing at D captures all three white stones.</p>];
     }
     config(): PuzzleConfig {
         return {
@@ -681,16 +506,6 @@ class Page16 extends Module5 {
     }
     text(): JSX.Element | Array<JSX.Element> {
         return [
-            <button key="playButton" onClick={this.playAudio}>
-                Play Audio
-            </button>,
-            <audio
-                key="audioElement"
-                ref={this.audioRef}
-                style={{ visibility: "hidden" }}
-                autoPlay={true}
-                src={this.audioUrl}
-            ></audio>,
             <p>
                 In Go, the placement of a single stone can make the difference between capturing a
                 large group or losing one of your own. That's part of the fun!


### PR DESCRIPTION
What was done:

1. The "Play Audio" button on the "learn-to-play" pages can now be toggled by clicking "Mute Audio", which pauses and mutes audio until the user clicks the "Play Audio" again

![image](https://github.com/online-go/kidsgoserver.com/assets/110797971/c96b220a-66b2-43e4-902c-a23c1a225b50)

2. Refactored code to have more of the logic be in the Lesson.tsx file (within the Lesson hook and useEffect) which makes it easier to read the code and allows us to control the state of the audio button in this file instead.

3. Made a small styling change to the LearnToPlay.tsx file (/learn-to-play page) where we see the 8 possible lessons.  The text below the numbers is now also clickable, and has a different color hover effect.

![image](https://github.com/online-go/kidsgoserver.com/assets/110797971/101b5102-7856-4588-bc7b-a82b775ac4a0)
