### PR TITLE
User Avatar player_cache bug, bot order bug, pass dialog

### DIFF
--- a/src/components/Avatar/PlayerAvatar.tsx
+++ b/src/components/Avatar/PlayerAvatar.tsx
@@ -28,9 +28,24 @@ export interface PlayerAvatarInterface {
 export function PlayerAvatar({ user_id }: PlayerAvatarInterface): JSX.Element {
     const [race, setRace] = React.useState<string>(null);
     const [idx, setIdx] = React.useState<number>();
-
+    console.log("player_cache", player_cache);
+    console.log("race, idx", race, idx);
     React.useEffect(() => {
         if (user_id) {
+            // First try to get data from localStorage if it's the current user
+            try {
+                const localUser = JSON.parse(localStorage.getItem("ogs.user"));
+                if (localUser && localUser.id === user_id) {
+                    const [r, i] = uiClassToRaceIdx(localUser.ui_class);
+                    setRace(r);
+                    setIdx(i);
+                    return; // Skip the fetch if we found the user in localStorage
+                }
+            } catch (e) {
+                console.error("Error reading from localStorage:", e);
+            }
+
+            // Fall back to player_cache if needed
             setRace(null);
             setIdx(null);
             player_cache

--- a/src/components/Avatar/PlayerAvatar.tsx
+++ b/src/components/Avatar/PlayerAvatar.tsx
@@ -28,24 +28,20 @@ export interface PlayerAvatarInterface {
 export function PlayerAvatar({ user_id }: PlayerAvatarInterface): JSX.Element {
     const [race, setRace] = React.useState<string>(null);
     const [idx, setIdx] = React.useState<number>();
-    console.log("player_cache", player_cache);
-    console.log("race, idx", race, idx);
+
     React.useEffect(() => {
         if (user_id) {
-            // First try to get data from localStorage if it's the current user
-            try {
-                const localUser = JSON.parse(localStorage.getItem("ogs.user"));
-                if (localUser && localUser.id === user_id) {
-                    const [r, i] = uiClassToRaceIdx(localUser.ui_class);
-                    setRace(r);
-                    setIdx(i);
-                    return; // Skip the fetch if we found the user in localStorage
-                }
-            } catch (e) {
-                console.error("Error reading from localStorage:", e);
+            // First try to get data from localStorage if it's the current user, since player_cache isn't properly updating, while the local storage value is
+            // Without this block, there was a bug where once we chose our avatar, then navigated to the game page and challenged a robot, it would show us the wrong avatar, until we refreshed the page
+            const localUser = JSON.parse(localStorage.getItem("ogs.user"));
+            if (localUser && localUser.id === user_id) {
+                const [r, i] = uiClassToRaceIdx(localUser.ui_class);
+                setRace(r);
+                setIdx(i);
+                return;
             }
 
-            // Fall back to player_cache if needed
+            // This block is needed to fetch the computer's avatar, this player_cache contains the user's previous avatar
             setRace(null);
             setIdx(null);
             player_cache

--- a/src/components/ChatDialog/ChatDialog.tsx
+++ b/src/components/ChatDialog/ChatDialog.tsx
@@ -41,6 +41,7 @@ export const ChatPhrases = [
 
     // required verbatim for our auto-chats, update in KidsGame.txt if these are changed.
     "I've passed.",
+    "I pass",
     "Your turn.",
 ];
 

--- a/src/components/ResultsDialog/ResultsDialog.styl
+++ b/src/components/ResultsDialog/ResultsDialog.styl
@@ -103,14 +103,6 @@ results-height=25rem;
                 }
             }
         }
-            .result-center-message{
-            display: flex;
-            justify-content: center;
-            padding: 1rem;
-            font-size: 1.75rem;
-            font-weight: bold;
-            }
-
 
         .score-stones {
             border-bottom: 2px solid;
@@ -154,6 +146,20 @@ results-height=25rem;
         }
     }
 
+    .result-center-message {
+        display: flex
+        justify-content: center
+        align-items: center
+        padding: 1rem 2rem
+        font-size: 1.75rem
+        font-weight: bold
+        background-color: rgba(34, 197, 94, 0.15)
+        color: #166534
+        border-radius: 0.75rem
+        margin: 1rem 0
+        text-shadow: 0 1px 2px rgba(255, 255, 255, 0.6)
+    }
+    
     .ResultsDialog-buttons {
         flex-shrink: 0;
 

--- a/src/components/ResultsDialog/ResultsDialog.styl
+++ b/src/components/ResultsDialog/ResultsDialog.styl
@@ -67,6 +67,8 @@ results-height=25rem;
         .result-text {
             display: block;
             min-height: 1.5rem;
+            padding-top: 0.5rem;
+            padding-bottom: 0.25rem;
         }
 
         > .black, > .white {
@@ -101,6 +103,14 @@ results-height=25rem;
                 }
             }
         }
+            .result-center-message{
+            display: flex;
+            justify-content: center;
+            padding: 1rem;
+            font-size: 1.75rem;
+            font-weight: bold;
+            }
+
 
         .score-stones {
             border-bottom: 2px solid;

--- a/src/components/ResultsDialog/ResultsDialog.tsx
+++ b/src/components/ResultsDialog/ResultsDialog.tsx
@@ -97,7 +97,7 @@ export function ResultsDialog(props: ResultsDialogProps): JSX.Element {
                     </div>
 
                     <div className="result-center-message">
-                        <div className="center-text">{userWon ? "You won!" : "They won"}</div>
+                        <div> {userWon ? "You won!" : "They won!"} </div>
                     </div>
 
                     <div className="white">
@@ -108,14 +108,7 @@ export function ResultsDialog(props: ResultsDialogProps): JSX.Element {
                         <div className="result-text">{right_winner}</div>
                     </div>
                 </div>
-                {/*
-                <div className="ResultsDialog-outcome">
-                    <div>
-                        <img className="stone-svg" src={winner_svg_url} />
-                        {outcome}
-                    </div>
-                </div>
-                */}
+
                 <div className="ResultsDialog-buttons">
                     <button className="primary-button" onClick={props.onPlayAgain}>
                         Play again

--- a/src/components/ResultsDialog/ResultsDialog.tsx
+++ b/src/components/ResultsDialog/ResultsDialog.tsx
@@ -64,7 +64,6 @@ export function ResultsDialog(props: ResultsDialogProps): JSX.Element {
         white_winner = "Wins by " + props.goban?.engine?.outcome;
         winner_svg_url = white_svg_url;
     }
-    const outcome = "wins by " + props.goban?.engine?.outcome;
 
     const swap = user.id === props.goban.engine.players.black.id;
 
@@ -81,6 +80,9 @@ export function ResultsDialog(props: ResultsDialogProps): JSX.Element {
     const left_score = swap ? score.white : score.black;
     const right_score = swap ? score.black : score.white;
 
+    const winnerId = props.goban?.engine?.winner;
+    const userWon = user.id === winnerId;
+
     return (
         <div className="ResultsDialog-container">
             <KBShortcut shortcut="esc" action={props.onClose} />
@@ -92,6 +94,10 @@ export function ResultsDialog(props: ResultsDialogProps): JSX.Element {
                         </div>
                         <Score score={left_score} other={right_score} svg_url={left_svg} />
                         <div className="result-text">{left_winner}</div>
+                    </div>
+
+                    <div className="result-center-message">
+                        <div className="center-text">{userWon ? "You won!" : "They won"}</div>
                     </div>
 
                     <div className="white">

--- a/src/views/KidsGame/KidsGame.tsx
+++ b/src/views/KidsGame/KidsGame.tsx
@@ -177,7 +177,7 @@ export function KidsGame(): JSX.Element {
                                     });
                                 }
                             }
-                        }, 15000);
+                        }, 10000);
                     }
                 }
             }
@@ -193,7 +193,16 @@ export function KidsGame(): JSX.Element {
                         if (goban.engine.last_official_move.passed()) {
                             const color = goban.engine.colorToMove();
                             const other_color = color === "black" ? "white" : "black";
+
                             animateCaptures([{ x: -1, y: -1 }], goban, other_color);
+
+                            const passPlayerID = goban.engine.players[other_color].id;
+
+                            // Emit the "I pass" message for both user and computer
+                            goban.emit("chat", {
+                                body: "I pass",
+                                player_id: passPlayerID,
+                            });
 
                             if (
                                 goban.engine.last_official_move.move_number > 1 &&
@@ -219,7 +228,6 @@ export function KidsGame(): JSX.Element {
         });
         goban.on("clear-message", () => {
             closePopup();
-            //console.log("clear message");
         });
 
         goban.on("audio-stone", (stone) =>

--- a/src/views/Matchmaking/ComputerOpponents.tsx
+++ b/src/views/Matchmaking/ComputerOpponents.tsx
@@ -53,42 +53,51 @@ export function ComputerOpponents(props: OpponentListProperties): JSX.Element {
         };
     }, []);
 
-    // Hardcoded names and avatars mapped to bots because we want specific names and a specific avatar without needing to show handicaps
-    const botOverrides = [
-        { name: "Beginner Bot", handicap: 4, ui_class: "aquatic-9" },
-        { name: "Weak Bot", handicap: 2, ui_class: "bird-5" },
-        { name: "Easy Bot", handicap: 0, ui_class: "fuzzball-23" },
-        { name: "Medium Bot", handicap: 0, ui_class: "robot-248" },
-        { name: "Hard Bot", handicap: 0, ui_class: "wisdom-2" },
-    ];
-
     return (
         <div className="OpponentList-container">
             <div className="OpponentList ComputerOpponents">
                 <h4>Computer Opponents</h4>
                 {(bots.length >= 1 || null) &&
-                    bots.slice(0, 5).map((bot, index) => {
-                        const { name, handicap, ui_class } = botOverrides[index];
-                        const [race, idx] = uiClassToRaceIdx(ui_class);
+                    bots
+                        .filter((bot) => !!bot.kidsgo_bot_name)
+                        .map((bot: any) => {
+                            const [race, idx] = uiClassToRaceIdx(bot.ui_class);
+                            const handicaps =
+                                bot.kidsgo_bot_name?.toLowerCase()?.indexOf("easy") >= 0
+                                    ? [4, 2, 0]
+                                    : [0];
 
-                        return (
-                            <span
-                                key={bot.id + "-" + handicap}
-                                className={
-                                    "bot" +
-                                    (props.value === bot.id &&
-                                    (props.handicap === handicap ||
-                                        (handicap === 0 && props.handicap > 0))
-                                        ? " active"
-                                        : "")
-                                }
-                                onClick={() => props.onChange(bot.id, handicap, bot)}
-                            >
-                                <Avatar race={race} idx={idx} />
-                                {name}
-                            </span>
-                        );
-                    })}
+                            return (
+                                <React.Fragment key={bot.id}>
+                                    {handicaps.map((handicap) => (
+                                        <span
+                                            key={bot.id + "-" + handicap}
+                                            className={
+                                                "bot" +
+                                                (props.value === bot.id &&
+                                                (handicaps.length === 1 ||
+                                                    props.handicap === handicap ||
+                                                    (handicap === 0 &&
+                                                        handicaps.indexOf(props.handicap) < 0))
+                                                    ? " active"
+                                                    : "")
+                                            }
+                                            onClick={() => {
+                                                props.onChange(bot.id, handicap, bot);
+                                            }}
+                                        >
+                                            <Avatar race={race} idx={idx} />
+                                            {bot.kidsgo_bot_name}
+                                            {handicap > 0
+                                                ? handicap === 1
+                                                    ? " with no Komi"
+                                                    : ` + ${handicap}`
+                                                : ""}
+                                        </span>
+                                    ))}
+                                </React.Fragment>
+                            );
+                        })}
             </div>
         </div>
     );

--- a/src/views/Matchmaking/ComputerOpponents.tsx
+++ b/src/views/Matchmaking/ComputerOpponents.tsx
@@ -32,7 +32,10 @@ interface OpponentListProperties {
 window["chat_manager"] = chat_manager;
 
 export function ComputerOpponents(props: OpponentListProperties): JSX.Element {
-    const [bots, setBots] = React.useState<Array<any>>(bots_list());
+    const sortBots = (botList: any[]) => {
+        return [...botList].sort((a, b) => a.id - b.id);
+    };
+    const [bots, setBots] = React.useState<Array<any>>(sortBots(bots_list()));
 
     React.useEffect(() => {
         const updateBots = (bots: any[]) => {
@@ -42,7 +45,7 @@ export function ComputerOpponents(props: OpponentListProperties): JSX.Element {
             }
             //list.sort((a, b) => getUserRating(a).rating - getUserRating(b).rating);
             // we created these in order of easy to hard, so just sort by id for now
-            list.sort((a, b) => a.id - b.id);
+            setBots(sortBots(list));
 
             setBots(list);
         };
@@ -69,32 +72,43 @@ export function ComputerOpponents(props: OpponentListProperties): JSX.Element {
 
                             return (
                                 <React.Fragment key={bot.id}>
-                                    {handicaps.map((handicap) => (
-                                        <span
-                                            key={bot.id + "-" + handicap}
-                                            className={
-                                                "bot" +
-                                                (props.value === bot.id &&
-                                                (handicaps.length === 1 ||
-                                                    props.handicap === handicap ||
-                                                    (handicap === 0 &&
-                                                        handicaps.indexOf(props.handicap) < 0))
-                                                    ? " active"
-                                                    : "")
+                                    {handicaps.map((handicap) => {
+                                        let botDisplayName = bot.kidsgo_bot_name;
+
+                                        if (
+                                            bot.kidsgo_bot_name?.toLowerCase()?.indexOf("easy") >= 0
+                                        ) {
+                                            if (handicap === 4) {
+                                                botDisplayName = "Beginner bot";
+                                            } else if (handicap === 2) {
+                                                botDisplayName = "Weak bot";
+                                            } else if (handicap === 0) {
+                                                botDisplayName = "Easy bot";
                                             }
-                                            onClick={() => {
-                                                props.onChange(bot.id, handicap, bot);
-                                            }}
-                                        >
-                                            <Avatar race={race} idx={idx} />
-                                            {bot.kidsgo_bot_name}
-                                            {handicap > 0
-                                                ? handicap === 1
-                                                    ? " with no Komi"
-                                                    : ` + ${handicap}`
-                                                : ""}
-                                        </span>
-                                    ))}
+                                        }
+
+                                        return (
+                                            <span
+                                                key={bot.id + "-" + handicap}
+                                                className={
+                                                    "bot" +
+                                                    (props.value === bot.id &&
+                                                    (handicaps.length === 1 ||
+                                                        props.handicap === handicap ||
+                                                        (handicap === 0 &&
+                                                            handicaps.indexOf(props.handicap) < 0))
+                                                        ? " active"
+                                                        : "")
+                                                }
+                                                onClick={() => {
+                                                    props.onChange(bot.id, handicap, bot);
+                                                }}
+                                            >
+                                                <Avatar race={race} idx={idx} />
+                                                {botDisplayName}
+                                            </span>
+                                        );
+                                    })}
                                 </React.Fragment>
                             );
                         })}


### PR DESCRIPTION
- Reverted code regarding manually changing the bot names and avatar, as it wasn't properly updating the computer avatar when we navigated to the game page, even though I did get it to show the correct avatar.  Unfortunately this means we get 3 "robot avatars" as the avatar, but that's probably better than seeing the wrong avatar in the game
- Now properly renders the player's avatar from local storage instead of the in-memory "player_cache". player_cache has some weird timing issue compared to local storage -> the player's avatar isn't updated in player_cache whereas it is updated in localstorage.  The bug was we would have to refresh the page to see the player's updated avatar
- The bots would sort improperly when we use the back arrow from the goban/game play page because the useEffect would not refire (which contained the sort logic), moved the logic outside of the useEffect, so it would sort for the initial state
- Made it so that a chat dialog of "I pass" would show up when either the opponent/bot or the user passes