### PR TITLE
Try again popup and puzzle adjustments

### DIFF
--- a/src/components/PopupDialog/PopupDialog.styl
+++ b/src/components/PopupDialog/PopupDialog.styl
@@ -90,3 +90,15 @@ popup-height=20rem;
         }
     }
 }
+
+.PopupDialog.no-buttons {
+    justify-content: center;
+    align-items: center;
+
+    .PopupDialog-text {
+        flex-grow: 0;
+        padding-top: 0;
+        padding-bottom: 0;
+        margin: auto;
+    }
+}

--- a/src/components/PopupDialog/PopupDialog.tsx
+++ b/src/components/PopupDialog/PopupDialog.tsx
@@ -27,19 +27,22 @@ interface PopupDialogProps {
 }
 
 export function PopupDialog(props: PopupDialogProps): JSX.Element {
+    const hasButtons = !!props.onAccept || !!props.onCancel;
     return (
         <div className="PopupDialog-container">
             <KBShortcut shortcut="esc" action={props.onCancel || props.onAccept || (() => 0)} />
-            <div className={`PopupDialog ${props.className || ""}`}>
+            <div
+                className={`PopupDialog ${props.className || ""} ${hasButtons ? "" : "no-buttons"}`}
+            >
                 <div className="PopupDialog-text">{props.text}</div>
-                <div className="PopupDialog-buttons">
-                    {(props.onAccept || null) && (
-                        <span className="green-check" onClick={props.onAccept} />
-                    )}
-                    {(props.onCancel || null) && (
-                        <span className="red-x" onClick={props.onCancel} />
-                    )}
-                </div>
+                {hasButtons && (
+                    <div className="PopupDialog-buttons">
+                        {props.onAccept && (
+                            <span className="green-check" onClick={props.onAccept} />
+                        )}
+                        {props.onCancel && <span className="red-x" onClick={props.onCancel} />}
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/src/views/Lessons/Module1.tsx
+++ b/src/views/Lessons/Module1.tsx
@@ -17,11 +17,11 @@
 
 import * as React from "react";
 import { Content } from "./Content";
-import { decodeMoves, PuzzleConfig, Goban, prettyCoordinates, JGOFNumericPlayerColor } from "goban";
+import { PuzzleConfig, Goban, JGOFNumericPlayerColor } from "goban";
 import { Axol } from "./Axol";
 import { openPopup } from "@kidsgo/components/PopupDialog";
 
-const POPUP_TIMEOUT = 3000;
+const POPUP_TIMEOUT = 1500;
 
 class Module1 extends Content {
     constructor(audioUrl: string, shouldPlayAudio?: boolean) {
@@ -319,6 +319,7 @@ class Puzzle1 extends Module1 {
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,
+                    no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
                 })
@@ -335,6 +336,7 @@ class Puzzle1 extends Module1 {
                 .then(() => {
                     return openPopup({
                         text: <Axol>Try again!</Axol>,
+                        no_accept: true,
                         no_cancel: true,
                         timeout: POPUP_TIMEOUT,
                     });
@@ -381,6 +383,7 @@ class Puzzle2 extends Module1 {
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,
+                    no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
                 })
@@ -397,6 +400,7 @@ class Puzzle2 extends Module1 {
                 .then(() => {
                     return openPopup({
                         text: <Axol>Try again!</Axol>,
+                        no_accept: true,
                         no_cancel: true,
                         timeout: POPUP_TIMEOUT,
                     });
@@ -442,6 +446,7 @@ class Puzzle3 extends Module1 {
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,
+                    no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
                 })
@@ -458,6 +463,7 @@ class Puzzle3 extends Module1 {
                 .then(() => {
                     return openPopup({
                         text: <Axol>Try again!</Axol>,
+                        no_accept: true,
                         no_cancel: true,
                         timeout: POPUP_TIMEOUT,
                     });
@@ -503,6 +509,7 @@ class Puzzle4 extends Module1 {
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,
+                    no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
                 })
@@ -519,6 +526,7 @@ class Puzzle4 extends Module1 {
                 .then(() => {
                     return openPopup({
                         text: <Axol>Try again!</Axol>,
+                        no_accept: true,
                         no_cancel: true,
                         timeout: POPUP_TIMEOUT,
                     });
@@ -564,6 +572,7 @@ class Puzzle5 extends Module1 {
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,
+                    no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
                 })
@@ -580,6 +589,7 @@ class Puzzle5 extends Module1 {
                 .then(() => {
                     return openPopup({
                         text: <Axol>Try again!</Axol>,
+                        no_accept: true,
                         no_cancel: true,
                         timeout: POPUP_TIMEOUT,
                     });
@@ -625,6 +635,7 @@ class Puzzle6 extends Module1 {
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,
+                    no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
                 })
@@ -641,6 +652,7 @@ class Puzzle6 extends Module1 {
                 .then(() => {
                     return openPopup({
                         text: <Axol>Try again!</Axol>,
+                        no_accept: true,
                         no_cancel: true,
                         timeout: POPUP_TIMEOUT,
                     });
@@ -686,6 +698,7 @@ class Puzzle7 extends Module1 {
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,
+                    no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
                 })
@@ -702,6 +715,7 @@ class Puzzle7 extends Module1 {
                 .then(() => {
                     return openPopup({
                         text: <Axol>Try again!</Axol>,
+                        no_accept: true,
                         no_cancel: true,
                         timeout: POPUP_TIMEOUT,
                     });
@@ -747,6 +761,7 @@ class Puzzle8 extends Module1 {
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,
+                    no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
                 })
@@ -763,6 +778,7 @@ class Puzzle8 extends Module1 {
                 .then(() => {
                     return openPopup({
                         text: <Axol>Try again!</Axol>,
+                        no_accept: true,
                         no_cancel: true,
                         timeout: POPUP_TIMEOUT,
                     });

--- a/src/views/Lessons/Module1.tsx
+++ b/src/views/Lessons/Module1.tsx
@@ -318,7 +318,7 @@ class Puzzle1 extends Module1 {
             }
             this.captureDelay(() => {
                 openPopup({
-                    text: <Axol>Very clever!</Axol>,
+                    text: <Axol>Good job!</Axol>,
                     no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
@@ -382,7 +382,7 @@ class Puzzle2 extends Module1 {
             }
             this.captureDelay(() => {
                 openPopup({
-                    text: <Axol>Very clever!</Axol>,
+                    text: <Axol>You did it!</Axol>,
                     no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
@@ -445,7 +445,7 @@ class Puzzle3 extends Module1 {
             }
             this.captureDelay(() => {
                 openPopup({
-                    text: <Axol>Very clever!</Axol>,
+                    text: <Axol>Nice work!</Axol>,
                     no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
@@ -547,7 +547,7 @@ class Puzzle5 extends Module1 {
             shouldPlayAudio,
         );
         this.successAudio = new Audio(
-            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472328/audio-slices-less-pauses/slice15_less_pauses_w7g2jr.mp3",
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708547864/audio-slices-less-pauses/slice13_less_pauses_revised_tanua8.mp3",
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -571,7 +571,7 @@ class Puzzle5 extends Module1 {
             }
             this.captureDelay(() => {
                 openPopup({
-                    text: <Axol>Very clever!</Axol>,
+                    text: <Axol>Good job!</Axol>,
                     no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
@@ -610,7 +610,7 @@ class Puzzle6 extends Module1 {
             shouldPlayAudio,
         );
         this.successAudio = new Audio(
-            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548659/audio-slices-less-pauses/slice19_less_pauses_revised_fykpjy.mp3",
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472328/audio-slices-less-pauses/slice15_less_pauses_w7g2jr.mp3",
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -634,7 +634,7 @@ class Puzzle6 extends Module1 {
             }
             this.captureDelay(() => {
                 openPopup({
-                    text: <Axol>Very clever!</Axol>,
+                    text: <Axol>You did it!</Axol>,
                     no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
@@ -673,7 +673,7 @@ class Puzzle7 extends Module1 {
             shouldPlayAudio,
         );
         this.successAudio = new Audio(
-            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548659/audio-slices-less-pauses/slice19_less_pauses_revised_fykpjy.mp3",
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472331/audio-slices-less-pauses/slice17_less_pauses_znln8h.mp3",
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
@@ -697,7 +697,7 @@ class Puzzle7 extends Module1 {
             }
             this.captureDelay(() => {
                 openPopup({
-                    text: <Axol>Very clever!</Axol>,
+                    text: <Axol>Nice work!</Axol>,
                     no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,

--- a/src/views/Lessons/Module2.tsx
+++ b/src/views/Lessons/Module2.tsx
@@ -428,11 +428,11 @@ class Puzzle1 extends Module2 {
     constructor() {
         super("no_audio_here");
         this.successAudio = new Audio(
-            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548659/audio-slices-less-pauses/slice19_less_pauses_revised_fykpjy.mp3",
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708547864/audio-slices-less-pauses/slice13_less_pauses_revised_tanua8.mp3",
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>Save the blue stones!</p>];
+        return [<p>Save the blue stones.</p>];
     }
     config(): PuzzleConfig {
         return {
@@ -452,7 +452,7 @@ class Puzzle1 extends Module2 {
             }
             this.captureDelay(() => {
                 openPopup({
-                    text: <Axol>Very clever!</Axol>,
+                    text: <Axol>Good job!</Axol>,
                     no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
@@ -488,11 +488,11 @@ class Puzzle2 extends Module2 {
     constructor() {
         super("no_audio_here");
         this.successAudio = new Audio(
-            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548659/audio-slices-less-pauses/slice19_less_pauses_revised_fykpjy.mp3",
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472328/audio-slices-less-pauses/slice15_less_pauses_w7g2jr.mp3",
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>Capture the 2 white stones!</p>];
+        return [<p>Capture the 2 white stones.</p>];
     }
     config(): PuzzleConfig {
         return {
@@ -512,7 +512,7 @@ class Puzzle2 extends Module2 {
             }
             this.captureDelay(() => {
                 openPopup({
-                    text: <Axol>Very clever!</Axol>,
+                    text: <Axol>You did it!</Axol>,
                     no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
@@ -548,11 +548,11 @@ class Puzzle3 extends Module2 {
     constructor() {
         super("no_audio_here");
         this.successAudio = new Audio(
-            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548659/audio-slices-less-pauses/slice19_less_pauses_revised_fykpjy.mp3",
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472331/audio-slices-less-pauses/slice17_less_pauses_znln8h.mp3",
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>Capture the 5 white stones!</p>];
+        return [<p>Capture the 5 white stones.</p>];
     }
     config(): PuzzleConfig {
         return {
@@ -572,7 +572,7 @@ class Puzzle3 extends Module2 {
             }
             this.captureDelay(() => {
                 openPopup({
-                    text: <Axol>Very clever!</Axol>,
+                    text: <Axol>Nice work!</Axol>,
                     no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
@@ -612,7 +612,7 @@ class Puzzle4 extends Module2 {
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>Save the 3 blue stones!</p>];
+        return [<p>Save the 3 blue stones.</p>];
     }
     config(): PuzzleConfig {
         return {
@@ -671,11 +671,11 @@ class Puzzle5 extends Module2 {
     constructor() {
         super("no_audio_here");
         this.successAudio = new Audio(
-            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548659/audio-slices-less-pauses/slice19_less_pauses_revised_fykpjy.mp3",
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708547864/audio-slices-less-pauses/slice13_less_pauses_revised_tanua8.mp3",
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>Save the 2 blue stones!</p>];
+        return [<p>Save the 2 blue stones.</p>];
     }
     config(): PuzzleConfig {
         return {
@@ -698,7 +698,7 @@ class Puzzle5 extends Module2 {
             }
             this.captureDelay(() => {
                 openPopup({
-                    text: <Axol>Very clever!</Axol>,
+                    text: <Axol>Good job!</Axol>,
                     no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
@@ -734,11 +734,11 @@ class Puzzle6 extends Module2 {
     constructor() {
         super("no_audio_here");
         this.successAudio = new Audio(
-            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708548659/audio-slices-less-pauses/slice19_less_pauses_revised_fykpjy.mp3",
+            "https://res.cloudinary.com/dn8rdavoi/video/upload/v1708472328/audio-slices-less-pauses/slice15_less_pauses_w7g2jr.mp3",
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>Capture some white stones!</p>];
+        return [<p>Capture some white stones.</p>];
     }
     config(): PuzzleConfig {
         return {
@@ -761,7 +761,7 @@ class Puzzle6 extends Module2 {
             }
             this.captureDelay(() => {
                 openPopup({
-                    text: <Axol>Very clever!</Axol>,
+                    text: <Axol>You did it!</Axol>,
                     no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
@@ -810,7 +810,13 @@ class Puzzle7 extends Module2 {
                 white: "B1C1D2E3G4F5E5D5C4B3A2",
             },
             move_tree: this.makePuzzleMoveTree(
-                ["F3E2B4A3C5", "F3E2F2F1B4A3C5"],
+                [
+                    "F3E2B4A3C5",
+                    "F3E2F2F1B4A3C5",
+                    "F3E2B4A3A4A1D1",
+                    "F3E2B4A3A4A1F2D1E1",
+                    "F3E2B4A3A4A1C5",
+                ],
                 [
                     "E2F3",
                     "B4F3",

--- a/src/views/Lessons/Module2.tsx
+++ b/src/views/Lessons/Module2.tsx
@@ -17,11 +17,11 @@
 
 import * as React from "react";
 import { Content } from "./Content";
-import { decodeMoves, PuzzleConfig, Goban, prettyCoordinates, JGOFNumericPlayerColor } from "goban";
+import { PuzzleConfig, Goban, JGOFNumericPlayerColor } from "goban";
 import { Axol } from "./Axol";
 import { openPopup } from "@kidsgo/components/PopupDialog";
 
-const POPUP_TIMEOUT = 3000;
+const POPUP_TIMEOUT = 1500;
 class Module2 extends Content {
     constructor(audioUrl: string) {
         super();
@@ -453,6 +453,7 @@ class Puzzle1 extends Module2 {
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,
+                    no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
                 })
@@ -469,6 +470,7 @@ class Puzzle1 extends Module2 {
                 .then(() => {
                     return openPopup({
                         text: <Axol>Try again!</Axol>,
+                        no_accept: true,
                         no_cancel: true,
                         timeout: POPUP_TIMEOUT,
                     });
@@ -511,6 +513,7 @@ class Puzzle2 extends Module2 {
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,
+                    no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
                 })
@@ -527,6 +530,7 @@ class Puzzle2 extends Module2 {
                 .then(() => {
                     return openPopup({
                         text: <Axol>Try again!</Axol>,
+                        no_accept: true,
                         no_cancel: true,
                         timeout: POPUP_TIMEOUT,
                     });
@@ -569,6 +573,7 @@ class Puzzle3 extends Module2 {
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,
+                    no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
                 })
@@ -585,6 +590,7 @@ class Puzzle3 extends Module2 {
                 .then(() => {
                     return openPopup({
                         text: <Axol>Try again!</Axol>,
+                        no_accept: true,
                         no_cancel: true,
                         timeout: POPUP_TIMEOUT,
                     });
@@ -630,6 +636,7 @@ class Puzzle4 extends Module2 {
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,
+                    no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
                 })
@@ -646,6 +653,7 @@ class Puzzle4 extends Module2 {
                 .then(() => {
                     return openPopup({
                         text: <Axol>Try again!</Axol>,
+                        no_accept: true,
                         no_cancel: true,
                         timeout: POPUP_TIMEOUT,
                     });
@@ -691,6 +699,7 @@ class Puzzle5 extends Module2 {
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,
+                    no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
                 })
@@ -707,6 +716,7 @@ class Puzzle5 extends Module2 {
                 .then(() => {
                     return openPopup({
                         text: <Axol>Try again!</Axol>,
+                        no_accept: true,
                         no_cancel: true,
                         timeout: POPUP_TIMEOUT,
                     });
@@ -752,6 +762,7 @@ class Puzzle6 extends Module2 {
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,
+                    no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
                 })
@@ -768,6 +779,7 @@ class Puzzle6 extends Module2 {
                 .then(() => {
                     return openPopup({
                         text: <Axol>Try again!</Axol>,
+                        no_accept: true,
                         no_cancel: true,
                         timeout: POPUP_TIMEOUT,
                     });
@@ -798,7 +810,7 @@ class Puzzle7 extends Module2 {
                 white: "B1C1D2E3G4F5E5D5C4B3A2",
             },
             move_tree: this.makePuzzleMoveTree(
-                ["F3E2B4A3C5"],
+                ["F3E2B4A3C5", "F3E2F2F1B4A3C5"],
                 [
                     "E2F3",
                     "B4F3",
@@ -824,6 +836,7 @@ class Puzzle7 extends Module2 {
             this.captureDelay(() => {
                 openPopup({
                     text: <Axol>Very clever!</Axol>,
+                    no_accept: true,
                     no_cancel: true,
                     timeout: POPUP_TIMEOUT,
                 })
@@ -840,6 +853,7 @@ class Puzzle7 extends Module2 {
                 .then(() => {
                     return openPopup({
                         text: <Axol>Try again!</Axol>,
+                        no_accept: true,
                         no_cancel: true,
                         timeout: POPUP_TIMEOUT,
                     });

--- a/src/views/Lessons/Module2.tsx
+++ b/src/views/Lessons/Module2.tsx
@@ -440,7 +440,7 @@ class Puzzle1 extends Module2 {
                 black: "C1D1D2E1",
                 white: "B1C2E2F1",
             },
-            move_tree: this.makePuzzleMoveTree(["D3"], []),
+            move_tree: this.makePuzzleMoveTree(["D3"], ["C3D3", "E3D3", "B2D3", "F2D3"]),
         };
     }
     onSetGoban(goban: Goban): void {

--- a/src/views/Lessons/Module2.tsx
+++ b/src/views/Lessons/Module2.tsx
@@ -738,7 +738,7 @@ class Puzzle6 extends Module2 {
         );
     }
     text(): JSX.Element | Array<JSX.Element> {
-        return [<p>Capture some white stones.</p>];
+        return [<p>Capture the 3 white stones.</p>];
     }
     config(): PuzzleConfig {
         return {


### PR DESCRIPTION
- Adjusted try again popup to auto close after 1.5 seconds instead of 3 seconds, not show the checkmark, and be centered in the container when there are no buttons to click
- Adjusted audio to have more variation instead of always being "Very clever!" and the associated popup text to match it
- Added a few more variations to a couple puzzles 
- Removed a few unused imports