### PR TITLE
Hint button wrong branch

### DIFF
--- a/src/lib/configure-goban.ts
+++ b/src/lib/configure-goban.ts
@@ -153,3 +153,15 @@ export function getSelectedThemes(): {
         "removal-scale": 1,
     };
 }
+
+export function setCustomMarkWithColor(
+    goban: Goban,
+    x: number,
+    y: number,
+    mark: string,
+    color: string,
+    drawSquare: boolean = true,
+) {
+    (goban as any).setMarkColor(x, y, color);
+    goban.setCustomMark(x, y, mark, drawSquare);
+}

--- a/src/views/Lessons/Puzzles.tsx
+++ b/src/views/Lessons/Puzzles.tsx
@@ -133,9 +133,8 @@ export function Puzzles({
 
         move.branches.forEach((item) => {
             goban.deleteCustomMark(item.x, item.y, "hint", false);
-            // Clear the mark color too, otherwise this only removes the green square marks
+            // Clear the mark color too, otherwise this only removes the green square marks and not the red marks
             delete goban.engine.cur_move.getMarks(item.x, item.y).color;
-            goban.drawSquare(item.x, item.y);
         });
         setHintsOn(false);
     };

--- a/src/views/Lessons/Puzzles.tsx
+++ b/src/views/Lessons/Puzzles.tsx
@@ -93,7 +93,6 @@ export function Puzzles({
         useState<boolean>(false);
     const [hintsOn, setHintsOn] = useState(false);
 
-    console.log("hintsOn value local state", hintsOn);
     const onResize = useCallback((width, height) => {
         const goban = goban_ref.current;
         if (goban) {
@@ -129,7 +128,6 @@ export function Puzzles({
     ));
 
     const removeHints = () => {
-        console.log("got to remove hints function!");
         const goban: Goban = goban_ref.current;
         const move = goban.engine.cur_move;
 
@@ -157,8 +155,8 @@ export function Puzzles({
 
             const branchesWrong = goban.engine.cur_move.findBranchesWithWrongAnswer();
             branchesWrong.forEach((branch) => {
-                // This if conditional is needed otherwise we duplicate draw a red mark behind the green mark it seems, which means
-                // if we hover over the green mark, it'll appear red on branches where there are multiple wrong moves
+                // This if conditional is needed otherwise we will sometimes draw a red mark on the same spot as the green mark,
+                // which means if we hover over the green mark, it'll appear red
                 if (!isCorrect(branch.x, branch.y)) {
                     setCustomMarkWithColor(goban, branch.x, branch.y, "hint", "red", true);
                 }
@@ -332,7 +330,12 @@ export function Puzzles({
                     <div id="left-container">
                         <div className="explanation-text" onClick={cancel_animation_ref.current}>
                             {/* {text} */}
-                            <div className="puzzle-sections">
+                            <div
+                                className="puzzle-sections"
+                                onClick={() => {
+                                    removeHints();
+                                }}
+                            >
                                 <h3>Problem Sections</h3>
                                 {sectionList}
                             </div>

--- a/src/views/Lessons/Puzzles.tsx
+++ b/src/views/Lessons/Puzzles.tsx
@@ -29,6 +29,7 @@ import { useNavigate } from "react-router-dom";
 import { animateCaptures } from "@kidsgo/lib/animateCaptures";
 import { BackButton } from "@kidsgo/components/BackButton";
 import { sfx } from "@/lib/sfx";
+import { setCustomMarkWithColor } from "@kidsgo/lib/configure-goban";
 import { sectionDisplayNames, sectionKeys, puzzleSectionMap } from "./PuzzleSections";
 
 export function Puzzles({
@@ -173,10 +174,16 @@ export function Puzzles({
 
         if (hintsOn) {
             removeHints();
-        } else if (!goban.engine.cur_move.correct_answer) {
-            const branches = goban.engine.cur_move.findBranchesWithCorrectAnswer();
-            branches.forEach((branch) => {
+        } else if (!goban.engine.cur_move.correct_answer || !goban.engine.cur_move.wrong_answer) {
+            const branchesRight = goban.engine.cur_move.findBranchesWithCorrectAnswer();
+            branchesRight.forEach((branch) => {
                 goban.setCustomMark(branch.x, branch.y, "hint", true);
+            });
+            const branchesWrong = goban.engine.cur_move.findBranchesWithWrongAnswer();
+            branchesWrong.forEach((branch) => {
+                // goban.setMarkColor(branch.x, branch.y, "red");
+                // goban.setCustomMark(branch.x, branch.y, "hint", true);
+                setCustomMarkWithColor(goban, branch.x, branch.y, "hint", "red", true);
             });
             setHintsOn(true);
         }
@@ -348,7 +355,6 @@ export function Puzzles({
                         <div className="explanation-text" onClick={cancel_animation_ref.current}>
                             {/* {text} */}
                             <div className="puzzle-sections">
-                                {/* <h3>Blue to play</h3> */}
                                 <h3>Problem Sections</h3>
                                 {sectionList}
                             </div>


### PR DESCRIPTION
- Cleaned up bad and unused duplicated code regarding hint button
- Now shows red squares for wrong branches on the Goban when clicking hint button
- Fixed bug causing hint button to not reset when navigating between sections by clicking the section from the left navigation
- Added code to MoveTree.ts (goban submodule), so that we can use those methods in kidsgo
- Because the following PR was merged, I updated the submodules in this PR too

PR made here: 

https://github.com/online-go/goban/pull/188
    