### PR TITLE
Avatar name update changes

### DIFF
--- a/src/views/CharacterSelection/CharacterSelection.tsx
+++ b/src/views/CharacterSelection/CharacterSelection.tsx
@@ -45,9 +45,11 @@ export function CharacterSelection(): JSX.Element {
     const last_ui_class = React.useRef<string>(raceIdxToUiClass(race, idx));
     const previousRace = React.useRef<Race>(race);
 
-    const refresh = async () => {
+    const refresh = async (ui_class_override?: string) => {
+        console.log("Refresh called with:", ui_class_override);
         const config = data.get("cached.config");
-        const ui_class = config?.user?.ui_class;
+        const ui_class = ui_class_override || config?.user?.ui_class;
+        console.log("Using ui_class:", ui_class);
         if (!ui_class) {
             return;
         }
@@ -67,28 +69,48 @@ export function CharacterSelection(): JSX.Element {
         }
     };
 
-    const update = async (newRace: Race, newIdx: number) => {
-        const new_ui_class = raceIdxToUiClass(newRace, newIdx);
+    // New function to handle race changes with username refresh
+    const handleRaceChange = async (newRace: Race, newIdx: number) => {
         const raceChanged = previousRace.current !== newRace;
+        const new_ui_class = raceIdxToUiClass(newRace, newIdx);
 
-        // Update UI immediately
         setAvatarRace(newRace);
         setAvatarIdx(newIdx);
         last_ui_class.current = new_ui_class;
 
+        if (raceChanged) {
+            previousRace.current = newRace;
+        }
+
         try {
             await post("kidsgo/update_avatar", { ui_class: new_ui_class });
 
-            const config = data.get("cached.config");
-            config.user.ui_class = new_ui_class;
-            data.setWithoutEmit("cached.config", config);
-            data.setWithoutEmit("config", config);
-            data.set("config.user", JSON.parse(JSON.stringify(config.user)));
-            data.set("user", JSON.parse(JSON.stringify(config.user)));
-
             if (raceChanged) {
-                previousRace.current = newRace;
-                await refresh();
+                // Generate new username and update everything at once
+                setRefreshing(true);
+                try {
+                    const newConfig = await post("kidsgo/regenerate_username", {
+                        ui_class: new_ui_class,
+                    });
+                    // Single atomic update - no separate config update needed
+                    data.set(cached.config, newConfig);
+                    data.setWithoutEmit("cached.config", newConfig);
+                    data.setWithoutEmit("config", newConfig);
+                    data.set("config.user", JSON.parse(JSON.stringify(newConfig.user)));
+                    data.set("user", JSON.parse(JSON.stringify(newConfig.user)));
+                } catch (err) {
+                    console.error("Failed to refresh name", err);
+                } finally {
+                    setRefreshing(false);
+                }
+            } else {
+                // Just update the avatar, no username change
+                const config = data.get("cached.config");
+                config.user.ui_class = new_ui_class;
+                data.setWithoutEmit("cached.config", config);
+                data.setWithoutEmit("config", config);
+                data.set("config.user", JSON.parse(JSON.stringify(config.user)));
+                data.set("user", JSON.parse(JSON.stringify(config.user)));
             }
         } catch (err) {
             console.error("Failed to update avatar", err);
@@ -99,8 +121,8 @@ export function CharacterSelection(): JSX.Element {
         <div id="CharacterSelection" className={avatar_background_class(avatarRace)}>
             <BackButton onClick={() => navigate("/play")} />
             <div className="HelpButton" onClick={() => navigate("/help")}></div>
-            <NameSelection refreshing={refreshing} onRefresh={refresh} />
-            <AvatarSelection race={avatarRace} idx={avatarIdx} onChange={update} />
+            <NameSelection refreshing={refreshing} onRefresh={() => refresh()} />
+            <AvatarSelection race={avatarRace} idx={avatarIdx} onChange={handleRaceChange} />
             <button className="ok" onClick={() => navigate("/play")}>
                 Done — I love it!
             </button>

--- a/src/views/CharacterSelection/CharacterSelection.tsx
+++ b/src/views/CharacterSelection/CharacterSelection.tsx
@@ -88,7 +88,7 @@ export function CharacterSelection(): JSX.Element {
 
             if (raceChanged) {
                 previousRace.current = newRace;
-                await refresh(); // reuse the existing refresh logic
+                await refresh();
             }
         } catch (err) {
             console.error("Failed to update avatar", err);

--- a/src/views/CharacterSelection/CharacterSelection.tsx
+++ b/src/views/CharacterSelection/CharacterSelection.tsx
@@ -46,10 +46,9 @@ export function CharacterSelection(): JSX.Element {
     const previousRace = React.useRef<Race>(race);
 
     const refresh = async (ui_class_override?: string) => {
-        console.log("Refresh called with:", ui_class_override);
         const config = data.get("cached.config");
         const ui_class = ui_class_override || config?.user?.ui_class;
-        console.log("Using ui_class:", ui_class);
+
         if (!ui_class) {
             return;
         }

--- a/src/views/CharacterSelection/CharacterSelection.tsx
+++ b/src/views/CharacterSelection/CharacterSelection.tsx
@@ -31,11 +31,10 @@ import {
     uiClassToRaceIdx,
     avatar_background_class,
 } from "@kidsgo/components/Avatar";
-import { openPopup } from "@kidsgo/components/PopupDialog";
-//import { SignIn } from "@kidsgo/views/SignIn";
 
 export function CharacterSelection(): JSX.Element {
     useEnsureUserIsCreated();
+
     const navigate = useNavigate();
     const user = useUser();
     const [race, idx] = uiClassToRaceIdx(user.ui_class);
@@ -44,98 +43,60 @@ export function CharacterSelection(): JSX.Element {
     const [refreshing, setRefreshing] = React.useState(false);
 
     const last_ui_class = React.useRef<string>(raceIdxToUiClass(race, idx));
-    const updating = React.useRef<boolean>(false);
     const previousRace = React.useRef<Race>(race);
 
-    const refresh = () => {
-        setRefreshing(true);
+    const refresh = async () => {
         const config = data.get("cached.config");
         const ui_class = config?.user?.ui_class;
-
-        post("kidsgo/regenerate_username", { ui_class })
-            .then((config) => {
-                data.set(cached.config, config);
-                console.log("should be ", config.user);
-                setRefreshing(false);
-            })
-            .catch((err) => {
-                console.error(err);
-                setRefreshing(false);
-            });
-    };
-
-    const update_server = (ui_class: string): void => {
-        last_ui_class.current = ui_class;
-        if (updating.current) {
+        if (!ui_class) {
             return;
         }
-        updating.current = true;
-        post("kidsgo/update_avatar", { ui_class })
-            .then(() => {
-                updating.current = false;
-                if (ui_class !== last_ui_class.current) {
-                    update_server(last_ui_class.current);
-                }
-            })
-            .catch((err) => {
-                updating.current = false;
-                console.error("Failed to update avatar", err);
-            });
+
+        setRefreshing(true);
+        try {
+            const newConfig = await post("kidsgo/regenerate_username", { ui_class });
+            data.set(cached.config, newConfig);
+            data.setWithoutEmit("cached.config", newConfig);
+            data.setWithoutEmit("config", newConfig);
+            data.set("config.user", JSON.parse(JSON.stringify(newConfig.user)));
+            data.set("user", JSON.parse(JSON.stringify(newConfig.user)));
+        } catch (err) {
+            console.error("Failed to refresh name", err);
+        } finally {
+            setRefreshing(false);
+        }
     };
 
-    const update = async (race: Race, idx: number): Promise<void> => {
-        const raceChanged = previousRace.current !== race;
+    const update = async (newRace: Race, newIdx: number) => {
+        const new_ui_class = raceIdxToUiClass(newRace, newIdx);
+        const raceChanged = previousRace.current !== newRace;
 
-        setAvatarRace(race);
-        setAvatarIdx(idx);
+        // Update UI immediately
+        setAvatarRace(newRace);
+        setAvatarIdx(newIdx);
+        last_ui_class.current = new_ui_class;
 
-        const new_ui_class = raceIdxToUiClass(race, idx);
+        try {
+            await post("kidsgo/update_avatar", { ui_class: new_ui_class });
 
-        // Update server first
-        await new Promise<void>((resolve, reject) => {
-            const updateServerAsync = (ui_class: string): void => {
-                last_ui_class.current = ui_class;
-                if (updating.current) {
-                    resolve();
-                    return;
-                }
-                updating.current = true;
-                post("kidsgo/update_avatar", { ui_class })
-                    .then(() => {
-                        updating.current = false;
-                        if (ui_class !== last_ui_class.current) {
-                            updateServerAsync(last_ui_class.current);
-                        } else {
-                            resolve();
-                        }
-                    })
-                    .catch((err) => {
-                        updating.current = false;
-                        console.error("Failed to update avatar", err);
-                        reject(err);
-                    });
-            };
-            updateServerAsync(new_ui_class);
-        });
+            const config = data.get("cached.config");
+            config.user.ui_class = new_ui_class;
+            data.setWithoutEmit("cached.config", config);
+            data.setWithoutEmit("config", config);
+            data.set("config.user", JSON.parse(JSON.stringify(config.user)));
+            data.set("user", JSON.parse(JSON.stringify(config.user)));
 
-        // Update local config after server update
-        const config = data.get("cached.config");
-        config.user.ui_class = new_ui_class;
-        data.setWithoutEmit("cached.config", config);
-        data.setWithoutEmit("config", config);
-        data.set("config.user", JSON.parse(JSON.stringify(config.user)));
-        data.set("user", JSON.parse(JSON.stringify(config.user)));
-
-        // Only trigger refresh when race changes, after avatar is fully updated
-        if (raceChanged) {
-            refresh();
+            if (raceChanged) {
+                previousRace.current = newRace;
+                await refresh(); // reuse the existing refresh logic
+            }
+        } catch (err) {
+            console.error("Failed to update avatar", err);
         }
-
-        previousRace.current = race;
     };
 
     return (
-        <div id="CharacterSelection" className={avatar_background_class(race)}>
+        <div id="CharacterSelection" className={avatar_background_class(avatarRace)}>
             <BackButton onClick={() => navigate("/play")} />
             <div className="HelpButton" onClick={() => navigate("/help")}></div>
             <NameSelection refreshing={refreshing} onRefresh={refresh} />

--- a/src/views/CharacterSelection/CharacterSelection.tsx
+++ b/src/views/CharacterSelection/CharacterSelection.tsx
@@ -45,6 +45,7 @@ export function CharacterSelection(): JSX.Element {
 
     const last_ui_class = React.useRef<string>(raceIdxToUiClass(race, idx));
     const updating = React.useRef<boolean>(false);
+    const previousRace = React.useRef<Race>(race); // Track previous race
 
     const refresh = () => {
         setRefreshing(true);
@@ -82,19 +83,55 @@ export function CharacterSelection(): JSX.Element {
             });
     };
 
-    const update = (race: Race, idx: number): void => {
+    const update = async (race: Race, idx: number): Promise<void> => {
+        const raceChanged = previousRace.current !== race;
+
         setAvatarRace(race);
         setAvatarIdx(idx);
-        update_server(raceIdxToUiClass(race, idx));
+
+        const new_ui_class = raceIdxToUiClass(race, idx);
+
+        // Update server first
+        await new Promise<void>((resolve, reject) => {
+            const updateServerAsync = (ui_class: string): void => {
+                last_ui_class.current = ui_class;
+                if (updating.current) {
+                    resolve();
+                    return;
+                }
+                updating.current = true;
+                post("kidsgo/update_avatar", { ui_class })
+                    .then(() => {
+                        updating.current = false;
+                        if (ui_class !== last_ui_class.current) {
+                            updateServerAsync(last_ui_class.current);
+                        } else {
+                            resolve();
+                        }
+                    })
+                    .catch((err) => {
+                        updating.current = false;
+                        console.error("Failed to update avatar", err);
+                        reject(err);
+                    });
+            };
+            updateServerAsync(new_ui_class);
+        });
+
+        // Update local config after server update
         const config = data.get("cached.config");
-        config.user.ui_class = raceIdxToUiClass(race, idx);
+        config.user.ui_class = new_ui_class;
         data.setWithoutEmit("cached.config", config);
         data.setWithoutEmit("config", config);
         data.set("config.user", JSON.parse(JSON.stringify(config.user)));
         data.set("user", JSON.parse(JSON.stringify(config.user)));
 
-        // Trigger refresh when avatar changes
-        refresh();
+        // Only trigger refresh when race changes, after avatar is fully updated
+        if (raceChanged) {
+            refresh();
+        }
+
+        previousRace.current = race;
     };
 
     return (

--- a/src/views/CharacterSelection/CharacterSelection.tsx
+++ b/src/views/CharacterSelection/CharacterSelection.tsx
@@ -83,50 +83,21 @@ export function CharacterSelection(): JSX.Element {
             });
     };
 
-    const update = async (race: Race, idx: number): Promise<void> => {
+    const update = (race: Race, idx: number): void => {
         const raceChanged = previousRace.current !== race;
 
         setAvatarRace(race);
         setAvatarIdx(idx);
+        update_server(raceIdxToUiClass(race, idx));
 
-        const new_ui_class = raceIdxToUiClass(race, idx);
-
-        // Update server first
-        await new Promise<void>((resolve, reject) => {
-            const updateServerAsync = (ui_class: string): void => {
-                last_ui_class.current = ui_class;
-                if (updating.current) {
-                    resolve();
-                    return;
-                }
-                updating.current = true;
-                post("kidsgo/update_avatar", { ui_class })
-                    .then(() => {
-                        updating.current = false;
-                        if (ui_class !== last_ui_class.current) {
-                            updateServerAsync(last_ui_class.current);
-                        } else {
-                            resolve();
-                        }
-                    })
-                    .catch((err) => {
-                        updating.current = false;
-                        console.error("Failed to update avatar", err);
-                        reject(err);
-                    });
-            };
-            updateServerAsync(new_ui_class);
-        });
-
-        // Update local config after server update
         const config = data.get("cached.config");
-        config.user.ui_class = new_ui_class;
+        config.user.ui_class = raceIdxToUiClass(race, idx);
         data.setWithoutEmit("cached.config", config);
         data.setWithoutEmit("config", config);
         data.set("config.user", JSON.parse(JSON.stringify(config.user)));
         data.set("user", JSON.parse(JSON.stringify(config.user)));
 
-        // Only trigger refresh when race changes, after avatar is fully updated
+        // Only trigger refresh when race changes, not idx
         if (raceChanged) {
             refresh();
         }

--- a/src/views/CharacterSelection/CharacterSelection.tsx
+++ b/src/views/CharacterSelection/CharacterSelection.tsx
@@ -90,7 +90,6 @@ export function CharacterSelection(): JSX.Element {
                     const newConfig = await post("kidsgo/regenerate_username", {
                         ui_class: new_ui_class,
                     });
-                    // Update cache
                     data.set(cached.config, newConfig);
                     data.setWithoutEmit("cached.config", newConfig);
                     data.setWithoutEmit("config", newConfig);

--- a/src/views/CharacterSelection/CharacterSelection.tsx
+++ b/src/views/CharacterSelection/CharacterSelection.tsx
@@ -36,23 +36,39 @@ import { openPopup } from "@kidsgo/components/PopupDialog";
 
 export function CharacterSelection(): JSX.Element {
     useEnsureUserIsCreated();
-
     const navigate = useNavigate();
     const user = useUser();
     const [race, idx] = uiClassToRaceIdx(user.ui_class);
     const [avatarRace, setAvatarRace] = React.useState<Race>(race);
     const [avatarIdx, setAvatarIdx] = React.useState(idx);
+    const [refreshing, setRefreshing] = React.useState(false);
+
     const last_ui_class = React.useRef<string>(raceIdxToUiClass(race, idx));
     const updating = React.useRef<boolean>(false);
+
+    const refresh = () => {
+        setRefreshing(true);
+        const config = data.get("cached.config");
+        const ui_class = config?.user?.ui_class;
+
+        post("kidsgo/regenerate_username", { ui_class })
+            .then((config) => {
+                data.set(cached.config, config);
+                console.log("should be ", config.user);
+                setRefreshing(false);
+            })
+            .catch((err) => {
+                console.error(err);
+                setRefreshing(false);
+            });
+    };
 
     const update_server = (ui_class: string): void => {
         last_ui_class.current = ui_class;
         if (updating.current) {
             return;
         }
-
         updating.current = true;
-
         post("kidsgo/update_avatar", { ui_class })
             .then(() => {
                 updating.current = false;
@@ -69,25 +85,24 @@ export function CharacterSelection(): JSX.Element {
     const update = (race: Race, idx: number): void => {
         setAvatarRace(race);
         setAvatarIdx(idx);
-
         update_server(raceIdxToUiClass(race, idx));
-
         const config = data.get("cached.config");
         config.user.ui_class = raceIdxToUiClass(race, idx);
         data.setWithoutEmit("cached.config", config);
         data.setWithoutEmit("config", config);
         data.set("config.user", JSON.parse(JSON.stringify(config.user)));
         data.set("user", JSON.parse(JSON.stringify(config.user)));
+
+        // Trigger refresh when avatar changes
+        refresh();
     };
 
     return (
         <div id="CharacterSelection" className={avatar_background_class(race)}>
             <BackButton onClick={() => navigate("/play")} />
             <div className="HelpButton" onClick={() => navigate("/help")}></div>
-            <NameSelection />
-
+            <NameSelection refreshing={refreshing} onRefresh={refresh} />
             <AvatarSelection race={avatarRace} idx={avatarIdx} onChange={update} />
-
             <button className="ok" onClick={() => navigate("/play")}>
                 Done — I love it!
             </button>
@@ -95,38 +110,24 @@ export function CharacterSelection(): JSX.Element {
     );
 }
 
-function NameSelection(): JSX.Element {
+function NameSelection({
+    refreshing,
+    onRefresh,
+}: {
+    refreshing: boolean;
+    onRefresh: () => void;
+}): JSX.Element {
     const user = useUser();
-    const [refreshing, setRefreshing] = React.useState(false);
 
     if (user.anonymous) {
         return <div className="NameSelection" />;
     }
 
-    console.log("user", user);
-
-    const config = data.get("cached.config");
-    const ui_class = config?.user?.ui_class;
-
-    const refresh = (e) => {
-        setRefreshing(true);
-        post("kidsgo/regenerate_username", { ui_class })
-            .then((config) => {
-                data.set(cached.config, config);
-                console.log("should be ", config.user);
-                setRefreshing(false);
-            })
-            .catch((err) => {
-                console.error(err);
-                setRefreshing(false);
-            });
-    };
-
     return (
         <div className={`NameSelection ${refreshing ? "refreshing" : ""}`}>
             <div className="title">PLAYER AVATAR</div>
             <div className="username">{user.username}</div>
-            <button className="refresh" onClick={refresh}>
+            <button className="refresh" onClick={onRefresh}>
                 Change Name
             </button>
         </div>


### PR DESCRIPTION
Purpose of this PR:

Avatar name now regenerates after the user switches alien types (planets) so that their username matches the new alien!

Other changes:

- The user's username won't change when switching within the same alien (when clicking the left/right arrows)
- Refactored "refresh" function logic so it's in the parent component, combined/simplified logic with server call and cache updates so we wouldn't get rerendering / username flickering issues, and avatar selection lag
- Renamed / combined several functions to be more clear ("refresh", "update", and "updateServer")
- Removed some className related code as it was pretending to be used, but it wasn't actually doing anything