### PR TITLE
Add void to navigate calls for compatibility

### DIFF
--- a/src/kidsgo-routes.tsx
+++ b/src/kidsgo-routes.tsx
@@ -52,7 +52,7 @@ function Main(props): JSX.Element {
                 return;
             }
 
-            navigate(`/game/${game.id}`);
+            void navigate(`/game/${game.id}`);
 
             console.log("Need to go to game", game.id);
         });

--- a/src/views/KidsGame/KidsGame.tsx
+++ b/src/views/KidsGame/KidsGame.tsx
@@ -286,11 +286,11 @@ export function KidsGame(): JSX.Element {
             })
                 .then(() => {
                     goban_ref.current.resign();
-                    navigate("/play");
+                    void navigate("/play");
                 })
                 .catch(() => 0);
         } else {
-            navigate("/play");
+            void navigate("/play");
         }
     }
 
@@ -307,7 +307,7 @@ export function KidsGame(): JSX.Element {
                 })
                 .catch(() => 0);
         } else {
-            navigate("/play");
+            void navigate("/play");
         }
     }
 
@@ -402,7 +402,7 @@ export function KidsGame(): JSX.Element {
                     <ResultsDialog
                         goban={goban_ref?.current}
                         onPlayAgain={() => {
-                            navigate("/play");
+                            void navigate("/play");
                         }}
                         onClose={() => {
                             setGameFinishedClosed(true);

--- a/src/views/LandingPage/LandingPage.tsx
+++ b/src/views/LandingPage/LandingPage.tsx
@@ -48,7 +48,7 @@ export function LandingPage(): JSX.Element {
         set_learn_to_play_launching(true);
 
         navigate_timeout = setTimeout(() => {
-            navigate("/learn-to-play");
+            void navigate("/learn-to-play");
         }, ROCKET_LAUNCH_DURATION * 1000);
     }
 
@@ -67,7 +67,7 @@ export function LandingPage(): JSX.Element {
 
         setTimeout(() => set_play_launching(false), 3000);
         navigate_timeout = setTimeout(() => {
-            navigate("/character-selection");
+            void navigate("/character-selection");
         }, ROCKET_LAUNCH_DURATION * 1000);
     }
 

--- a/src/views/LearnToPlay/LearnToPlay.tsx
+++ b/src/views/LearnToPlay/LearnToPlay.tsx
@@ -29,7 +29,7 @@ export function LearnToPlay(): JSX.Element {
     const navigate = useNavigate();
 
     function back() {
-        navigate("/");
+        void navigate("/");
     }
 
     return (
@@ -148,11 +148,11 @@ export function ChapterButton({ chapter }: { chapter: number }): JSX.Element {
             className={"ChapterButton" + ` chapter-${chapter}`}
             onClick={() => {
                 if (chapter === 8 && last_visited_lesson_8_page != null) {
-                    navigate(last_visited_lesson_8_page);
+                    void navigate(last_visited_lesson_8_page);
                 } else if (chapter === 8) {
-                    navigate(`/learn-to-play/8/problems/capturing/1`);
+                    void navigate(`/learn-to-play/8/problems/capturing/1`);
                 } else {
-                    navigate(`/learn-to-play/${chapter}`);
+                    void navigate(`/learn-to-play/${chapter}`);
                 }
             }}
         >

--- a/src/views/Matchmaking/Matchmaking.tsx
+++ b/src/views/Matchmaking/Matchmaking.tsx
@@ -59,7 +59,7 @@ export function Matchmaking(): JSX.Element {
     React.useEffect(() => {
         const t = setTimeout(
             () => {
-                navigate("/");
+                void navigate("/");
             },
             60 * 60 * 1000,
         );
@@ -241,13 +241,13 @@ export function Matchmaking(): JSX.Element {
     };
     const playOrView = (e) => {
         if (game_to_view) {
-            navigate(`/game/${game_to_view.id}`);
+            void navigate(`/game/${game_to_view.id}`);
         } else {
             play(e);
         }
     };
     function back() {
-        navigate("/");
+        void navigate("/");
     }
     const setOpponentAndHandicap = (o: string, h: number, opponent_obj: any) => {
         setOpponent(o);
@@ -445,7 +445,7 @@ function CheckForChallengeReceived(): JSX.Element {
             } else if (notification.type === "gameEnded") {
                 notification_manager.deleteNotification(notification);
             } else if (notification.type === "gameStarted") {
-                navigate(`/game/${notification.game_id}`);
+                void navigate(`/game/${notification.game_id}`);
                 notification_manager.deleteNotification(notification);
             } else if (notification.type === "delete") {
                 console.log("delete notification:", notification, active_challenge);
@@ -470,7 +470,7 @@ function CheckForChallengeReceived(): JSX.Element {
         post(`me/challenges/${active_challenge.current.challenge_id}/accept`, {})
             .then(() => {
                 if (active_challenge.current) {
-                    navigate(`/game/${active_challenge.current.game_id}`);
+                    void navigate(`/game/${active_challenge.current.game_id}`);
                 }
             })
             .catch((err) => {


### PR DESCRIPTION
- Eslint was getting mad at floating promises regarding the navigate calls because React-router-dom v7 treats them differently now