### PR TITLE
First capture game mode

### DIFF
--- a/src/components/Captures/Captures.tsx
+++ b/src/components/Captures/Captures.tsx
@@ -45,6 +45,7 @@ export function Captures({ color, goban }: CapturesProps): JSX.Element {
                 const mode = searchParams.get("mode");
 
                 // Don't count pass stones in our capture game mode, this avoids a bug where if the user wins, the opponent is forced to pass and we get one extra prisoner in the bowl
+                // Also, we don't let users click the pass button in the capture game mode now either, so this ensures consistency
                 return mode === "capture"
                     ? prisoners[color].prisoners
                     : prisoners[color].prisoners + passes[color];

--- a/src/components/Captures/Captures.tsx
+++ b/src/components/Captures/Captures.tsx
@@ -18,6 +18,7 @@
 import * as React from "react";
 import { Goban } from "goban";
 import { countPasses } from "@kidsgo/lib/countPasses";
+import { useSearchParams } from "react-router-dom";
 
 interface CapturesProps {
     color: "black" | "white";
@@ -35,18 +36,26 @@ function yrandpercent(i: number): number {
 export function Captures({ color, goban }: CapturesProps): JSX.Element {
     //const [r, refresh] = React.useState(0);
     const [numCaptures, setNumCaptures] = React.useState(goban?.engine[color + "_prisoners"] || 0);
-
+    const [searchParams, setSearchParams] = useSearchParams();
     React.useEffect(() => {
         if (goban) {
             const passes = countPasses(goban);
             const prisoners = goban.engine.computeScore(true); // true for prisoners only scoring
-            const captures = prisoners[color].prisoners + passes[color];
+            let captures =
+                searchParams.get("mode") === "capture"
+                    ? prisoners[color].prisoners + passes[color]
+                    : prisoners[color].prisoners;
             setNumCaptures(captures);
 
             const doDelayedRefresh = () => {
                 const passes = countPasses(goban);
                 const prisoners = goban.engine.computeScore(true); // true for prisoners only scoring
-                const captures = prisoners[color].prisoners + passes[color];
+                if (searchParams.get("mode") === "capture") {
+                    captures = prisoners[color].prisoners;
+                } else {
+                    captures = prisoners[color].prisoners + passes[color];
+                }
+
                 setTimeout(() => {
                     setNumCaptures(captures);
                 }, 3000);
@@ -54,7 +63,11 @@ export function Captures({ color, goban }: CapturesProps): JSX.Element {
             const doImmediateRefresh = () => {
                 const passes = countPasses(goban);
                 const prisoners = goban.engine.computeScore(true); // true for prisoners only scoring
-                const captures = prisoners[color].prisoners + passes[color];
+                if (searchParams.get("mode") === "capture") {
+                    captures = prisoners[color].prisoners;
+                } else {
+                    captures = prisoners[color].prisoners + passes[color];
+                }
                 setNumCaptures(captures);
             };
 

--- a/src/components/Captures/Captures.tsx
+++ b/src/components/Captures/Captures.tsx
@@ -39,36 +39,26 @@ export function Captures({ color, goban }: CapturesProps): JSX.Element {
     const [searchParams, setSearchParams] = useSearchParams();
     React.useEffect(() => {
         if (goban) {
-            const passes = countPasses(goban);
-            const prisoners = goban.engine.computeScore(true); // true for prisoners only scoring
-            let captures =
-                searchParams.get("mode") === "capture"
-                    ? prisoners[color].prisoners + passes[color]
-                    : prisoners[color].prisoners;
-            setNumCaptures(captures);
-
-            const doDelayedRefresh = () => {
+            const computeCaptures = () => {
                 const passes = countPasses(goban);
                 const prisoners = goban.engine.computeScore(true); // true for prisoners only scoring
-                if (searchParams.get("mode") === "capture") {
-                    captures = prisoners[color].prisoners;
-                } else {
-                    captures = prisoners[color].prisoners + passes[color];
-                }
+                const mode = searchParams.get("mode");
 
+                // Don't count pass stones in our capture game mode, this avoids a bug where if the user wins, the opponent is forced to pass and we get one extra prisoner in the bowl
+                return mode === "capture"
+                    ? prisoners[color].prisoners
+                    : prisoners[color].prisoners + passes[color];
+            };
+
+            setNumCaptures(computeCaptures());
+
+            const doDelayedRefresh = () => {
                 setTimeout(() => {
-                    setNumCaptures(captures);
+                    setNumCaptures(computeCaptures());
                 }, 3000);
             };
             const doImmediateRefresh = () => {
-                const passes = countPasses(goban);
-                const prisoners = goban.engine.computeScore(true); // true for prisoners only scoring
-                if (searchParams.get("mode") === "capture") {
-                    captures = prisoners[color].prisoners;
-                } else {
-                    captures = prisoners[color].prisoners + passes[color];
-                }
-                setNumCaptures(captures);
+                setNumCaptures(computeCaptures());
             };
 
             goban.on("captured-stones", doDelayedRefresh);

--- a/src/components/PopupDialog/PopupDialog.tsx
+++ b/src/components/PopupDialog/PopupDialog.tsx
@@ -65,18 +65,6 @@ interface OpenPopupProps {
     timeout?: number;
 }
 
-// Helper function to filter out suppressed error messages
-// function filterErrorMessage(text: string | React.ReactNode): string | React.ReactNode {
-//     if (typeof text === "string" && text.includes("Error: Game is not in progress")) {
-//         console.log("hit this block, returning empty error string");
-//         // return "";
-//         return;
-//         // return true;
-//     }
-//     return text;
-//     // return text; // Return original text for everything else
-// }
-
 let root: ReactDOM.Root;
 
 export function openPopup(props: OpenPopupProps): Promise<void> {
@@ -122,7 +110,6 @@ export function openPopup(props: OpenPopupProps): Promise<void> {
         <React.StrictMode>
             <PopupDialog
                 text={props.text}
-                // text={filterErrorMessage(props.text)}
                 className={props.className}
                 onAccept={props.no_accept ? undefined : onaccept}
                 onCancel={props.no_cancel ? undefined : oncancel}

--- a/src/components/PopupDialog/PopupDialog.tsx
+++ b/src/components/PopupDialog/PopupDialog.tsx
@@ -65,9 +65,25 @@ interface OpenPopupProps {
     timeout?: number;
 }
 
+// Helper function to filter out suppressed error messages
+// function filterErrorMessage(text: string | React.ReactNode): string | React.ReactNode {
+//     if (typeof text === "string" && text.includes("Error: Game is not in progress")) {
+//         console.log("hit this block, returning empty error string");
+//         // return "";
+//         return;
+//         // return true;
+//     }
+//     return text;
+//     // return text; // Return original text for everything else
+// }
+
 let root: ReactDOM.Root;
 
 export function openPopup(props: OpenPopupProps): Promise<void> {
+    if (typeof props.text === "string" && props.text.includes("Error: Game is not in progress")) {
+        console.log("Suppressing popup for game not in progress error");
+        return Promise.resolve(); // Don't create any popup at all
+    }
     const container = document.createElement("DIV");
     document.body.append(container);
 
@@ -106,6 +122,7 @@ export function openPopup(props: OpenPopupProps): Promise<void> {
         <React.StrictMode>
             <PopupDialog
                 text={props.text}
+                // text={filterErrorMessage(props.text)}
                 className={props.className}
                 onAccept={props.no_accept ? undefined : onaccept}
                 onCancel={props.no_cancel ? undefined : oncancel}

--- a/src/components/ResultsDialog/ResultsDialog.tsx
+++ b/src/components/ResultsDialog/ResultsDialog.tsx
@@ -24,14 +24,15 @@ import { countPasses } from "@kidsgo/lib/countPasses";
 
 interface ResultsDialogProps {
     goban?: Goban;
-    captureWin?: boolean;
-    captureWinPlayer?: Number;
     onPlayAgain: () => void;
     onClose: () => void;
 }
 
 export function ResultsDialog(props: ResultsDialogProps): JSX.Element {
     const user = useUser();
+    const captureWinPlayer = Number(localStorage.getItem("captureWinPlayer") || "0");
+    const isCaptureWin = localStorage.getItem("captureWin") === "true";
+    const isResignation = props.goban?.engine?.outcome === "Resignation";
 
     if (!props.goban) {
         return null;
@@ -45,9 +46,6 @@ export function ResultsDialog(props: ResultsDialogProps): JSX.Element {
     const passes = countPasses(props.goban);
     score.black.prisoners = score_prisoners.black.prisoners + passes.black;
     score.white.prisoners = score_prisoners.white.prisoners + passes.white;
-
-    const isResignation = props.goban?.engine?.outcome === "Resignation";
-    const isCaptureWin = props.captureWin;
 
     const black_svg_url = ((props.goban as any)?.theme_black?.getSadStoneSvgUrl() || "").replace(
         "sad",
@@ -106,7 +104,7 @@ export function ResultsDialog(props: ResultsDialogProps): JSX.Element {
                         <div className="result-center-message">
                             {isCaptureWin ? (
                                 <div>
-                                    {props.captureWinPlayer === user.id
+                                    {captureWinPlayer === user.id
                                         ? "You won by capturing them first!"
                                         : "They won by capturing you first!"}
                                 </div>

--- a/src/components/ResultsDialog/ResultsDialog.tsx
+++ b/src/components/ResultsDialog/ResultsDialog.tsx
@@ -37,7 +37,6 @@ export function ResultsDialog(props: ResultsDialogProps): JSX.Element {
         return null;
     }
 
-    console.log("captureWinPlayer", props.captureWinPlayer);
     // We usually use area scoring for aga, so the computeScore doesn't return
     // captures. But in this case the AGF wants us to report in territory scoring,
     // so we adjust.

--- a/src/components/ResultsDialog/ResultsDialog.tsx
+++ b/src/components/ResultsDialog/ResultsDialog.tsx
@@ -25,6 +25,7 @@ import { countPasses } from "@kidsgo/lib/countPasses";
 interface ResultsDialogProps {
     goban?: Goban;
     captureWin?: boolean;
+    captureWinPlayer?: Number;
     onPlayAgain: () => void;
     onClose: () => void;
 }
@@ -36,6 +37,7 @@ export function ResultsDialog(props: ResultsDialogProps): JSX.Element {
         return null;
     }
 
+    console.log("captureWinPlayer", props.captureWinPlayer);
     // We usually use area scoring for aga, so the computeScore doesn't return
     // captures. But in this case the AGF wants us to report in territory scoring,
     // so we adjust.
@@ -47,7 +49,6 @@ export function ResultsDialog(props: ResultsDialogProps): JSX.Element {
 
     const isResignation = props.goban?.engine?.outcome === "Resignation";
     const isCaptureWin = props.captureWin;
-    console.log("isCaptureWin INSIDE RESULTSDIALOG COMPONENT", isCaptureWin);
 
     const black_svg_url = ((props.goban as any)?.theme_black?.getSadStoneSvgUrl() || "").replace(
         "sad",
@@ -106,7 +107,7 @@ export function ResultsDialog(props: ResultsDialogProps): JSX.Element {
                         <div className="result-center-message">
                             {isCaptureWin ? (
                                 <div>
-                                    {!userWon
+                                    {props.captureWinPlayer === user.id
                                         ? "You won by capturing them first!"
                                         : "They won by capturing you first!"}
                                 </div>

--- a/src/components/ResultsDialog/ResultsDialog.tsx
+++ b/src/components/ResultsDialog/ResultsDialog.tsx
@@ -24,6 +24,7 @@ import { countPasses } from "@kidsgo/lib/countPasses";
 
 interface ResultsDialogProps {
     goban?: Goban;
+    captureWin?: boolean;
     onPlayAgain: () => void;
     onClose: () => void;
 }
@@ -45,6 +46,8 @@ export function ResultsDialog(props: ResultsDialogProps): JSX.Element {
     score.white.prisoners = score_prisoners.white.prisoners + passes.white;
 
     const isResignation = props.goban?.engine?.outcome === "Resignation";
+    const isCaptureWin = props.captureWin;
+    console.log("isCaptureWin INSIDE RESULTSDIALOG COMPONENT", isCaptureWin);
 
     const black_svg_url = ((props.goban as any)?.theme_black?.getSadStoneSvgUrl() || "").replace(
         "sad",
@@ -101,9 +104,19 @@ export function ResultsDialog(props: ResultsDialogProps): JSX.Element {
                         </div>
 
                         <div className="result-center-message">
-                            <div>
-                                {userWon ? "They resigned, you won!" : "You resigned, they won!"}
-                            </div>
+                            {isCaptureWin ? (
+                                <div>
+                                    {!userWon
+                                        ? "You won by capturing them first!"
+                                        : "They won by capturing you first!"}
+                                </div>
+                            ) : (
+                                <div>
+                                    {userWon
+                                        ? "They resigned, you won!"
+                                        : "You resigned, they won!"}
+                                </div>
+                            )}
                         </div>
 
                         <div className="white">

--- a/src/kidsgo-routes.tsx
+++ b/src/kidsgo-routes.tsx
@@ -52,7 +52,14 @@ function Main(props): JSX.Element {
                 return;
             }
 
-            void navigate(`/game/${game.id}`);
+            const savedGameMode = localStorage.getItem("gameMode");
+
+            let navigationUrl = `/game/${game.id}`;
+            if (savedGameMode === "capture") {
+                navigationUrl += "?mode=capture";
+            }
+
+            void navigate(navigationUrl);
 
             console.log("Need to go to game", game.id);
         });

--- a/src/views/HelpPage/HelpPage.tsx
+++ b/src/views/HelpPage/HelpPage.tsx
@@ -21,7 +21,7 @@ import { BackButton } from "@kidsgo/components/BackButton";
 const helpSections = [
     { id: "avatars", title: "Avatars" },
     { id: "starting", title: "Starting a Game" },
-    { id: "firstCapture", title: "First Capture" },
+    { id: "captureGo", title: "Capture Go" },
     { id: "boards", title: "Board Sizes" },
     { id: "ending", title: "Ending the Game" },
     { id: "scoring", title: "Scoring the Game" },
@@ -118,13 +118,13 @@ export function HelpPage(): JSX.Element {
                     {isMobile && <BackToTopButton />}
                 </section>
 
-                <section id="firstCapture">
-                    <h2>First Capture</h2>
+                <section id="captureGo">
+                    <h2>Capture Go</h2>
                     <p>
                         This is a training game for Go, with fewer rules. Whoever captures one or
                         more stones wins, and then you can start a new game. It is helpful for very
                         young children who aren’t old enough to play Go. 4 and 5 year old kids can
-                        start with First Capture, and progress to full Go when they are ready.
+                        start with Capture Go, and progress to Regular Go when they are ready.
                     </p>
                     {isMobile && <BackToTopButton />}
                 </section>

--- a/src/views/HelpPage/HelpPage.tsx
+++ b/src/views/HelpPage/HelpPage.tsx
@@ -21,6 +21,7 @@ import { BackButton } from "@kidsgo/components/BackButton";
 const helpSections = [
     { id: "avatars", title: "Avatars" },
     { id: "starting", title: "Starting a Game" },
+    { id: "firstCapture", title: "First Capture" },
     { id: "boards", title: "Board Sizes" },
     { id: "ending", title: "Ending the Game" },
     { id: "scoring", title: "Scoring the Game" },
@@ -113,6 +114,17 @@ export function HelpPage(): JSX.Element {
                         It will take a few games with a player to see what the right handicap should
                         be. If you don’t know, just play even. If someone wins 2 or more times,
                         adjust the handicap.
+                    </p>
+                    {isMobile && <BackToTopButton />}
+                </section>
+
+                <section id="firstCapture">
+                    <h2>First Capture</h2>
+                    <p>
+                        This is a training game for Go, with fewer rules. Whoever captures one or
+                        more stones wins, and then you can start a new game. It is helpful for very
+                        young children who aren’t old enough to play Go. 4 and 5 year old kids can
+                        start with First Capture, and progress to full Go when they are ready.
                     </p>
                     {isMobile && <BackToTopButton />}
                 </section>

--- a/src/views/KidsGame/KidsGame.tsx
+++ b/src/views/KidsGame/KidsGame.tsx
@@ -150,15 +150,16 @@ export function KidsGame(): JSX.Element {
             const currentMode = new URLSearchParams(window.location.search).get("mode");
             if (currentMode === "capture") {
                 setCaptureWin(true);
+                localStorage.setItem("captureWin", "true");
                 const playerToMove = goban.engine.playerToMove();
 
                 if (playerToMove !== user?.id) {
                     console.log("Opponent resigns.");
-                    setCaptureWinPlayer(user?.id);
+                    localStorage.setItem("captureWinPlayer", user?.id?.toString() || "0");
                     goban_ref.current.resign(); // TODO: Need to force OPPONENT to resign or disable board clicks instead. This only works because I'm setting the winner manually, but the Goban / internal state thinks we always resign and thus lost the game
                 } else {
                     console.log("User resigns.");
-                    setCaptureWinPlayer(opponent?.id);
+                    localStorage.setItem("captureWinPlayer", opponent?.id?.toString() || "0");
                     goban_ref.current.resign();
                 }
             }
@@ -297,6 +298,9 @@ export function KidsGame(): JSX.Element {
                 goban.redraw(true);
             }, 1);
             clearInterval(animation_interval);
+            // Clear the capture winner and captureWin boolean value from localStorage so the winner is reset before we start the next game we play
+            localStorage.removeItem("captureWinPlayer");
+            localStorage.removeItem("captureWin");
         };
     }, [game_id, container]);
 
@@ -428,8 +432,7 @@ export function KidsGame(): JSX.Element {
                 {phase === "finished" && !gameFinishedClosed && (
                     <ResultsDialog
                         goban={goban_ref?.current}
-                        captureWin={captureWin}
-                        captureWinPlayer={captureWinPlayer} // HACK: id of player that won, won't match internal state because the USER always resigns to make the Go board not interactable
+                        // captureWin={captureWin}
                         onPlayAgain={() => {
                             void navigate("/play");
                         }}

--- a/src/views/KidsGame/KidsGame.tsx
+++ b/src/views/KidsGame/KidsGame.tsx
@@ -396,16 +396,6 @@ export function KidsGame(): JSX.Element {
         : "Friend";
     */
 
-    // const winner_username =
-    //     `${goban_ref.current?.engine.winner}` === `${user.id}`
-    //         ? "You"
-    //         : goban_ref.current?.engine.player_pool[goban_ref.current?.engine.winner]?.username;
-
-    // const result =
-    //     phase === "finished" && winner_username === "You"
-    //         ? "You have won by " + goban_ref.current?.engine.outcome
-    //         : winner_username + " wins by " + goban_ref.current?.engine.outcome;
-
     return (
         <>
             <div id="KidsGame" className={race ? avatar_background_class(race as Race) : ""}>

--- a/src/views/KidsGame/KidsGame.tsx
+++ b/src/views/KidsGame/KidsGame.tsx
@@ -154,7 +154,7 @@ export function KidsGame(): JSX.Element {
                 if (playerToMove !== user?.id) {
                     console.log("Opponent resigns.");
                     setCaptureWinPlayer(user?.id);
-                    goban_ref.current.resign(); // TODO: Need to force OPPONENT to resign, this only works because I'm setting the winner manually, but the Goban / internal state thinks we always resign and thus lost the game
+                    goban_ref.current.resign(); // TODO: Need to force OPPONENT to resign or disable board clicks instead. This only works because I'm setting the winner manually, but the Goban / internal state thinks we always resign and thus lost the game
                 } else {
                     console.log("User resigns.");
                     setCaptureWinPlayer(opponent?.id);

--- a/src/views/KidsGame/KidsGame.tsx
+++ b/src/views/KidsGame/KidsGame.tsx
@@ -63,6 +63,8 @@ export function KidsGame(): JSX.Element {
     const phase = usePhase(goban_ref.current);
     //const [race] = uiClassToRaceIdx(user.ui_class);
     const [whiteId, setWhiteId] = useState(0);
+    const [captureWin, setCaptureWin] = useState(false);
+    console.log("captureWin", captureWin);
     const race = usePlayerRace(whiteId);
 
     const game_id = parseInt(params.id);
@@ -138,7 +140,19 @@ export function KidsGame(): JSX.Element {
         };
 
         const onCapturedStones = ({ removed_stones }) => {
+            console.log("hit onCapturedStones function!");
             animateCaptures(removed_stones, goban, goban.engine.colorToMove());
+
+            if (removed_stones && removed_stones.length > 0) {
+                console.log("got inside to set state of captureWin to true");
+                console.log("goban.engine.phase", goban.engine.phase);
+                setCaptureWin(true);
+                setTimeout(() => {
+                    if (goban_ref.current && goban_ref.current.engine.phase === "play") {
+                        goban_ref.current.resign();
+                    }
+                }, 1000);
+            }
         };
 
         let last_player_to_move = 0;
@@ -374,15 +388,15 @@ export function KidsGame(): JSX.Element {
         : "Friend";
     */
 
-    const winner_username =
-        `${goban_ref.current?.engine.winner}` === `${user.id}`
-            ? "You"
-            : goban_ref.current?.engine.player_pool[goban_ref.current?.engine.winner]?.username;
+    // const winner_username =
+    //     `${goban_ref.current?.engine.winner}` === `${user.id}`
+    //         ? "You"
+    //         : goban_ref.current?.engine.player_pool[goban_ref.current?.engine.winner]?.username;
 
-    const result =
-        phase === "finished" && winner_username === "You"
-            ? "You have won by " + goban_ref.current?.engine.outcome
-            : winner_username + " wins by " + goban_ref.current?.engine.outcome;
+    // const result =
+    //     phase === "finished" && winner_username === "You"
+    //         ? "You have won by " + goban_ref.current?.engine.outcome
+    //         : winner_username + " wins by " + goban_ref.current?.engine.outcome;
 
     return (
         <>

--- a/src/views/KidsGame/KidsGame.tsx
+++ b/src/views/KidsGame/KidsGame.tsx
@@ -144,19 +144,17 @@ export function KidsGame(): JSX.Element {
             console.log("hit onCapturedStones function!");
             animateCaptures(removed_stones, goban, goban.engine.colorToMove());
 
-            if (removed_stones && removed_stones.length > 0) {
-                setCaptureWin(true);
-                const playerToMove = goban.engine.playerToMove();
+            setCaptureWin(true);
+            const playerToMove = goban.engine.playerToMove();
 
-                if (playerToMove !== user?.id) {
-                    console.log("Opponent resigns.");
-                    setCaptureWinPlayer(user?.id);
-                    goban_ref.current.resign(); // TODO: Need to force OPPONENT to resign, this technically works because I'm setting the winner manually, but the Goban / internal state thinks we always resign and thus lost
-                } else {
-                    console.log("User resigns.");
-                    setCaptureWinPlayer(opponent?.id);
-                    goban_ref.current.resign();
-                }
+            if (playerToMove !== user?.id) {
+                console.log("Opponent resigns.");
+                setCaptureWinPlayer(user?.id);
+                goban_ref.current.resign(); // TODO: Need to force OPPONENT to resign, this technically works because I'm setting the winner manually, but the Goban / internal state thinks we always resign and thus lost
+            } else {
+                console.log("User resigns.");
+                setCaptureWinPlayer(opponent?.id);
+                goban_ref.current.resign();
             }
         };
 

--- a/src/views/KidsGame/KidsGame.tsx
+++ b/src/views/KidsGame/KidsGame.tsx
@@ -216,6 +216,7 @@ export function KidsGame(): JSX.Element {
                     /* If we just joined the game, don't replay the animation */
                     if (pass_last_move !== 0) {
                         if (goban.engine.last_official_move.passed()) {
+                            console.log("Hello from inner passStrongHandler()!");
                             const color = goban.engine.colorToMove();
                             const other_color = color === "black" ? "white" : "black";
 
@@ -299,8 +300,10 @@ export function KidsGame(): JSX.Element {
         };
     }, [game_id, container]);
 
+    // There's a small chance (1/10) or specific sequence where the url initially contains the query string "?mode=capture", but then gets removed,
+    // this causes a bug where the user thinks they are playing the capture game, but because the query string is missing, they aren't
+    // This code adds the query string back if localStorage says we should be in capture mode
     useEffect(() => {
-        // If localStorage says capture mode but URL doesn't have it, restore it (happens in weird edge cases, maybe 1/10 times)
         if (localStorage.getItem("gameMode") === "capture" && mode !== "capture") {
             setSearchParams({ mode: "capture" });
             console.log("Restored missing ?mode=capture to URL");
@@ -389,7 +392,10 @@ export function KidsGame(): JSX.Element {
         user.id !== player_to_move &&
         user.id in (goban_ref.current?.engine.player_pool || {}) &&
         move_number > 1;
-    const can_pass = user.id === player_to_move;
+    console.log("searchParams[mode]", searchParams.get("mode"));
+    // Always disable the pass button in our capture game mode, this way we can make sure the pass prisoners are never shown in the Captures component.
+    // This prevents potential data inconsistencies from the user passing in the capture game (is makes no sense why the user would pass in this game mode, but this prevents them from doing it altogether)
+    const can_pass = user.id === player_to_move && searchParams.get("mode") !== "capture";
     const bot_game =
         isBot(goban_ref.current?.engine.players.black) ||
         isBot(goban_ref.current?.engine.players.white);

--- a/src/views/KidsGame/KidsGame.tsx
+++ b/src/views/KidsGame/KidsGame.tsx
@@ -432,7 +432,6 @@ export function KidsGame(): JSX.Element {
                 {phase === "finished" && !gameFinishedClosed && (
                     <ResultsDialog
                         goban={goban_ref?.current}
-                        // captureWin={captureWin}
                         onPlayAgain={() => {
                             void navigate("/play");
                         }}

--- a/src/views/KidsGame/KidsGame.tsx
+++ b/src/views/KidsGame/KidsGame.tsx
@@ -70,7 +70,6 @@ export function KidsGame(): JSX.Element {
     const [searchParams, setSearchParams] = useSearchParams();
     const mode = searchParams.get("mode");
 
-    console.log("mode", mode);
     const race = usePlayerRace(whiteId);
 
     const game_id = parseInt(params.id);

--- a/src/views/KidsGame/KidsGame.tsx
+++ b/src/views/KidsGame/KidsGame.tsx
@@ -64,7 +64,8 @@ export function KidsGame(): JSX.Element {
     //const [race] = uiClassToRaceIdx(user.ui_class);
     const [whiteId, setWhiteId] = useState(0);
     const [captureWin, setCaptureWin] = useState(false);
-    console.log("captureWin", captureWin);
+    const [captureWinPlayer, setCaptureWinPlayer] = useState(0);
+
     const race = usePlayerRace(whiteId);
 
     const game_id = parseInt(params.id);
@@ -155,11 +156,13 @@ export function KidsGame(): JSX.Element {
                 // setTimeout(() => {
                 const playerToMove = goban.engine.playerToMove();
 
-                if (playerToMove !== user.id) {
+                if (playerToMove !== user?.id) {
                     console.log("Opponent resigns.");
-                    goban_ref.current.resign(); // TODO: Need to force OPPONENT to resign
+                    setCaptureWinPlayer(user?.id);
+                    goban_ref.current.resign(); // TODO: Need to force OPPONENT to resign, this technically works because I'm setting the winner manually, but the Goban / internal state thinks we always resign and thus lost
                 } else {
                     console.log("User resigns.");
+                    setCaptureWinPlayer(opponent?.id);
                     goban_ref.current.resign();
                 }
                 // }
@@ -428,6 +431,7 @@ export function KidsGame(): JSX.Element {
                     <ResultsDialog
                         goban={goban_ref?.current}
                         captureWin={captureWin}
+                        captureWinPlayer={captureWinPlayer}
                         onPlayAgain={() => {
                             void navigate("/play");
                         }}

--- a/src/views/KidsGame/KidsGame.tsx
+++ b/src/views/KidsGame/KidsGame.tsx
@@ -18,7 +18,7 @@
 import * as React from "react";
 import * as data from "@/lib/data";
 import { sfx } from "@/lib/sfx";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { useResizeDetector } from "react-resize-detector";
 import { useState, useEffect, useRef, useCallback } from "react";
 import { _ } from "@/lib/translate";
@@ -51,6 +51,7 @@ export function KidsGame(): JSX.Element {
     const user = data.get("user");
 
     const params = useParams();
+
     const navigate = useNavigate();
     const container = useRef<HTMLDivElement>(null);
     const goban_ref = useRef<Goban>(null);
@@ -66,6 +67,10 @@ export function KidsGame(): JSX.Element {
     const [captureWin, setCaptureWin] = useState(false);
     const [captureWinPlayer, setCaptureWinPlayer] = useState(0);
 
+    const [searchParams, _] = useSearchParams();
+    const mode = searchParams.get("mode");
+
+    console.log("mode", mode);
     const race = usePlayerRace(whiteId);
 
     const game_id = parseInt(params.id);
@@ -141,20 +146,21 @@ export function KidsGame(): JSX.Element {
         };
 
         const onCapturedStones = ({ removed_stones }) => {
-            console.log("hit onCapturedStones function!");
             animateCaptures(removed_stones, goban, goban.engine.colorToMove());
 
-            setCaptureWin(true);
-            const playerToMove = goban.engine.playerToMove();
+            if (mode === "capture") {
+                setCaptureWin(true);
+                const playerToMove = goban.engine.playerToMove();
 
-            if (playerToMove !== user?.id) {
-                console.log("Opponent resigns.");
-                setCaptureWinPlayer(user?.id);
-                goban_ref.current.resign(); // TODO: Need to force OPPONENT to resign, this technically works because I'm setting the winner manually, but the Goban / internal state thinks we always resign and thus lost
-            } else {
-                console.log("User resigns.");
-                setCaptureWinPlayer(opponent?.id);
-                goban_ref.current.resign();
+                if (playerToMove !== user?.id) {
+                    console.log("Opponent resigns.");
+                    setCaptureWinPlayer(user?.id);
+                    goban_ref.current.resign(); // TODO: Need to force OPPONENT to resign, this only works because I'm setting the winner manually, but the Goban / internal state thinks we always resign and thus lost the game
+                } else {
+                    console.log("User resigns.");
+                    setCaptureWinPlayer(opponent?.id);
+                    goban_ref.current.resign();
+                }
             }
         };
 

--- a/src/views/KidsGame/KidsGame.tsx
+++ b/src/views/KidsGame/KidsGame.tsx
@@ -67,7 +67,7 @@ export function KidsGame(): JSX.Element {
     const [captureWin, setCaptureWin] = useState(false);
     const [captureWinPlayer, setCaptureWinPlayer] = useState(0);
 
-    const [searchParams, _] = useSearchParams();
+    const [searchParams, setSearchParams] = useSearchParams();
     const mode = searchParams.get("mode");
 
     console.log("mode", mode);

--- a/src/views/KidsGame/KidsGame.tsx
+++ b/src/views/KidsGame/KidsGame.tsx
@@ -154,9 +154,12 @@ export function KidsGame(): JSX.Element {
                 const playerToMove = goban.engine.playerToMove();
 
                 if (playerToMove !== user?.id) {
-                    console.log("Opponent resigns.");
+                    console.log(
+                        "Opponent resigns (currently user is ALWAYS resigning to lock board state though).",
+                    );
                     localStorage.setItem("captureWinPlayer", user?.id?.toString() || "0");
-                    goban_ref.current.resign(); // TODO: Need to force OPPONENT to resign or disable board clicks instead. This only works because I'm setting the winner manually, but the Goban / internal state thinks we always resign and thus lost the game
+                    // TODO: Need to force OPPONENT to resign or disable board clicks instead. This only works because I'm setting the winner manually, but the Goban / internal state thinks we always resign and thus lost the game
+                    goban_ref.current.resign();
                 } else {
                     console.log("User resigns.");
                     localStorage.setItem("captureWinPlayer", opponent?.id?.toString() || "0");
@@ -217,7 +220,6 @@ export function KidsGame(): JSX.Element {
                     /* If we just joined the game, don't replay the animation */
                     if (pass_last_move !== 0) {
                         if (goban.engine.last_official_move.passed()) {
-                            console.log("Hello from inner passStrongHandler()!");
                             const color = goban.engine.colorToMove();
                             const other_color = color === "black" ? "white" : "black";
 
@@ -251,7 +253,6 @@ export function KidsGame(): JSX.Element {
                 text: formatted,
                 no_cancel: true,
             });
-            //console.log("show-message", formatted, message_id, parameters);
         });
         goban.on("clear-message", () => {
             closePopup();
@@ -396,7 +397,6 @@ export function KidsGame(): JSX.Element {
         user.id !== player_to_move &&
         user.id in (goban_ref.current?.engine.player_pool || {}) &&
         move_number > 1;
-    console.log("searchParams[mode]", searchParams.get("mode"));
     // Always disable the pass button in our capture game mode, this way we can make sure the pass prisoners are never shown in the Captures component.
     // This prevents potential data inconsistencies from the user passing in the capture game (is makes no sense why the user would pass in this game mode, but this prevents them from doing it altogether)
     const can_pass = user.id === player_to_move && searchParams.get("mode") !== "capture";

--- a/src/views/KidsGame/KidsGame.tsx
+++ b/src/views/KidsGame/KidsGame.tsx
@@ -398,7 +398,7 @@ export function KidsGame(): JSX.Element {
         user.id in (goban_ref.current?.engine.player_pool || {}) &&
         move_number > 1;
     // Always disable the pass button in our capture game mode, this way we can make sure the pass prisoners are never shown in the Captures component.
-    // This prevents potential data inconsistencies from the user passing in the capture game (is makes no sense why the user would pass in this game mode, but this prevents them from doing it altogether)
+    // This prevents potential data inconsistencies from the user passing in the capture game (it makes no sense why the user would pass in this game mode, but this prevents them from doing it altogether)
     const can_pass = user.id === player_to_move && searchParams.get("mode") !== "capture";
     const bot_game =
         isBot(goban_ref.current?.engine.players.black) ||

--- a/src/views/KidsGame/KidsGame.tsx
+++ b/src/views/KidsGame/KidsGame.tsx
@@ -132,10 +132,6 @@ export function KidsGame(): JSX.Element {
             );
             mvs.map((p) => prettyCoordinates(p.x, p.y, goban.height));
 
-            // console.log("BLACK ID", goban_ref.current?.engine.players.black.id);
-            // console.log("WHITE ID", goban_ref.current?.engine.players.white.id);
-            // console.log("PLAYERS", goban_ref.current?.engine.players);
-            // console.log("CURRENT PLAYER", user.id);
             const isResignation = goban?.engine?.outcome === "Resignation";
 
             if (goban.engine.phase === "finished" && !isResignation) {
@@ -149,11 +145,7 @@ export function KidsGame(): JSX.Element {
             animateCaptures(removed_stones, goban, goban.engine.colorToMove());
 
             if (removed_stones && removed_stones.length > 0) {
-                console.log("got inside to set state of captureWin to true");
-                // console.log("goban.engine.phase", goban.engine.phase);
                 setCaptureWin(true);
-
-                // setTimeout(() => {
                 const playerToMove = goban.engine.playerToMove();
 
                 if (playerToMove !== user?.id) {
@@ -165,8 +157,6 @@ export function KidsGame(): JSX.Element {
                     setCaptureWinPlayer(opponent?.id);
                     goban_ref.current.resign();
                 }
-                // }
-                // }, 3000);
             }
         };
 
@@ -431,7 +421,7 @@ export function KidsGame(): JSX.Element {
                     <ResultsDialog
                         goban={goban_ref?.current}
                         captureWin={captureWin}
-                        captureWinPlayer={captureWinPlayer}
+                        captureWinPlayer={captureWinPlayer} // HACK: id of player that won, won't match internal state because the USER always resigns to make the Go board not interactable
                         onPlayAgain={() => {
                             void navigate("/play");
                         }}

--- a/src/views/KidsGame/KidsGame.tsx
+++ b/src/views/KidsGame/KidsGame.tsx
@@ -131,6 +131,10 @@ export function KidsGame(): JSX.Element {
             );
             mvs.map((p) => prettyCoordinates(p.x, p.y, goban.height));
 
+            // console.log("BLACK ID", goban_ref.current?.engine.players.black.id);
+            // console.log("WHITE ID", goban_ref.current?.engine.players.white.id);
+            // console.log("PLAYERS", goban_ref.current?.engine.players);
+            // console.log("CURRENT PLAYER", user.id);
             const isResignation = goban?.engine?.outcome === "Resignation";
 
             if (goban.engine.phase === "finished" && !isResignation) {
@@ -145,13 +149,21 @@ export function KidsGame(): JSX.Element {
 
             if (removed_stones && removed_stones.length > 0) {
                 console.log("got inside to set state of captureWin to true");
-                console.log("goban.engine.phase", goban.engine.phase);
+                // console.log("goban.engine.phase", goban.engine.phase);
                 setCaptureWin(true);
-                setTimeout(() => {
-                    if (goban_ref.current && goban_ref.current.engine.phase === "play") {
-                        goban_ref.current.resign();
-                    }
-                }, 1000);
+
+                // setTimeout(() => {
+                const playerToMove = goban.engine.playerToMove();
+
+                if (playerToMove !== user.id) {
+                    console.log("Opponent resigns.");
+                    goban_ref.current.resign(); // TODO: Need to force OPPONENT to resign
+                } else {
+                    console.log("User resigns.");
+                    goban_ref.current.resign();
+                }
+                // }
+                // }, 3000);
             }
         };
 
@@ -415,6 +427,7 @@ export function KidsGame(): JSX.Element {
                 {phase === "finished" && !gameFinishedClosed && (
                     <ResultsDialog
                         goban={goban_ref?.current}
+                        captureWin={captureWin}
                         onPlayAgain={() => {
                             void navigate("/play");
                         }}

--- a/src/views/KidsGame/KidsGame.tsx
+++ b/src/views/KidsGame/KidsGame.tsx
@@ -147,7 +147,8 @@ export function KidsGame(): JSX.Element {
         const onCapturedStones = ({ removed_stones }) => {
             animateCaptures(removed_stones, goban, goban.engine.colorToMove());
 
-            if (mode === "capture") {
+            const currentMode = new URLSearchParams(window.location.search).get("mode");
+            if (currentMode === "capture") {
                 setCaptureWin(true);
                 const playerToMove = goban.engine.playerToMove();
 
@@ -297,6 +298,14 @@ export function KidsGame(): JSX.Element {
             clearInterval(animation_interval);
         };
     }, [game_id, container]);
+
+    useEffect(() => {
+        // If localStorage says capture mode but URL doesn't have it, restore it (happens in weird edge cases, maybe 1/10 times)
+        if (localStorage.getItem("gameMode") === "capture" && mode !== "capture") {
+            setSearchParams({ mode: "capture" });
+            console.log("Restored missing ?mode=capture to URL");
+        }
+    }, [mode]);
 
     function quit() {
         if (

--- a/src/views/Matchmaking/ComputerOpponents.tsx
+++ b/src/views/Matchmaking/ComputerOpponents.tsx
@@ -54,44 +54,43 @@ export function ComputerOpponents(props: OpponentListProperties): JSX.Element {
         };
     }, []);
 
+    // Auto-select Easy bot and sync parent state when we have choose the captureGame mode
     React.useEffect(() => {
         if (props.captureGame) {
             const easyBot = bots.find(
                 (bot) => bot.kidsgo_bot_name?.toLowerCase()?.includes("easy"),
             );
-            if (easyBot && (!props.value || props.value !== easyBot.id || props.handicap !== 0)) {
-                // Auto-select Easy bot and sync parent state
+            if (easyBot) {
                 props.onChange(easyBot.id, 0, easyBot);
             }
         }
     }, [props.captureGame, bots]);
-    // Early return for capture mode - only show Easy bot
+
+    // If we are in captureGame mode, only show Easy bot as it's the best bot for playing first capture because it's weak
     if (props.captureGame) {
         const easyBot = bots.find((bot) => bot.kidsgo_bot_name?.toLowerCase()?.includes("easy"));
 
-        if (!easyBot) {
-            return;
-        }
+        if (easyBot) {
+            const [race, idx] = uiClassToRaceIdx(easyBot.ui_class);
+            const isSelected = props.value === easyBot.id && props.handicap === 0;
 
-        const [race, idx] = uiClassToRaceIdx(easyBot.ui_class);
-        const isSelected = props.value === easyBot.id && props.handicap === 0;
-
-        return (
-            <div className="OpponentList-container">
-                <div className="OpponentList ComputerOpponents">
-                    <h4>Bots to Play</h4>
-                    <span
-                        className={`bot ${isSelected ? "active" : ""}`}
-                        onClick={() => {
-                            props.onChange(easyBot.id, 0, easyBot);
-                        }}
-                    >
-                        <Avatar race={race} idx={idx} />
-                        Easy
-                    </span>
+            return (
+                <div className="OpponentList-container">
+                    <div className="OpponentList ComputerOpponents">
+                        <h4>Bots to Play</h4>
+                        <span
+                            className={`bot ${isSelected ? "active" : ""}`}
+                            onClick={() => {
+                                props.onChange(easyBot.id, 0, easyBot);
+                            }}
+                        >
+                            <Avatar race={race} idx={idx} />
+                            Easy
+                        </span>
+                    </div>
                 </div>
-            </div>
-        );
+            );
+        }
     }
 
     return (

--- a/src/views/Matchmaking/ComputerOpponents.tsx
+++ b/src/views/Matchmaking/ComputerOpponents.tsx
@@ -26,6 +26,7 @@ interface OpponentListProperties {
     channel: string;
     value: string;
     handicap: number;
+    captureGame?: boolean;
     onChange: (user: string, handicap: number, full_user: any) => void;
 }
 
@@ -53,6 +54,46 @@ export function ComputerOpponents(props: OpponentListProperties): JSX.Element {
         };
     }, []);
 
+    React.useEffect(() => {
+        if (props.captureGame) {
+            const easyBot = bots.find(
+                (bot) => bot.kidsgo_bot_name?.toLowerCase()?.includes("easy"),
+            );
+            if (easyBot && (!props.value || props.value !== easyBot.id || props.handicap !== 0)) {
+                // Auto-select Easy bot and sync parent state
+                props.onChange(easyBot.id, 0, easyBot);
+            }
+        }
+    }, [props.captureGame, bots]);
+    // Early return for capture mode - only show Easy bot
+    if (props.captureGame) {
+        const easyBot = bots.find((bot) => bot.kidsgo_bot_name?.toLowerCase()?.includes("easy"));
+
+        if (!easyBot) {
+            return;
+        }
+
+        const [race, idx] = uiClassToRaceIdx(easyBot.ui_class);
+        const isSelected = props.value === easyBot.id && props.handicap === 0;
+
+        return (
+            <div className="OpponentList-container">
+                <div className="OpponentList ComputerOpponents">
+                    <h4>Bots to Play</h4>
+                    <span
+                        className={`bot ${isSelected ? "active" : ""}`}
+                        onClick={() => {
+                            props.onChange(easyBot.id, 0, easyBot);
+                        }}
+                    >
+                        <Avatar race={race} idx={idx} />
+                        Easy
+                    </span>
+                </div>
+            </div>
+        );
+    }
+
     return (
         <div className="OpponentList-container">
             <div className="OpponentList ComputerOpponents">
@@ -60,6 +101,7 @@ export function ComputerOpponents(props: OpponentListProperties): JSX.Element {
                 {(bots.length >= 1 || null) &&
                     bots
                         .filter((bot) => !!bot.kidsgo_bot_name)
+
                         .map((bot: any) => {
                             const [race, idx] = uiClassToRaceIdx(bot.ui_class);
                             const handicaps =

--- a/src/views/Matchmaking/Matchmaking.styl
+++ b/src/views/Matchmaking/Matchmaking.styl
@@ -229,11 +229,13 @@
         align-items: center;
         align-content: center;
 
-
         .color-selector {
             margin: 0.4rem;
             display: inline-flex;
             flex-direction: column;
+        }
+        .gamemode-spacer {
+            margin-top: 0.5rem;
         }
         
         select {

--- a/src/views/Matchmaking/Matchmaking.styl
+++ b/src/views/Matchmaking/Matchmaking.styl
@@ -46,7 +46,7 @@
         padding: 1rem;
         border-radius: 0.5rem;
         border: 1px solid #fff;
-        max-height: 80vh;
+        max-height: 75vh;
         overflow: auto;
     }
 

--- a/src/views/Matchmaking/Matchmaking.tsx
+++ b/src/views/Matchmaking/Matchmaking.tsx
@@ -229,7 +229,7 @@ export function Matchmaking(): JSX.Element {
                 }
 
                 function checkForReject(notification) {
-                    console.log("challenge rejection check notification:", notification);
+                    // console.log("challenge rejection check notification:", notification);
                     if (notification.type === "gameOfferRejected") {
                         /* non checked delete to purge old notifications that
                          * could be around after browser refreshes, connection

--- a/src/views/Matchmaking/Matchmaking.tsx
+++ b/src/views/Matchmaking/Matchmaking.tsx
@@ -414,7 +414,7 @@ export function Matchmaking(): JSX.Element {
                 </div>
                 <div className="settings">
                     <div className="gamemode-spacer">
-                        Game Mode:
+                        Game:
                         <input
                             type="radio"
                             id="normal-game"

--- a/src/views/Matchmaking/Matchmaking.tsx
+++ b/src/views/Matchmaking/Matchmaking.tsx
@@ -410,23 +410,25 @@ export function Matchmaking(): JSX.Element {
                     <label htmlFor="board-size-13">13x13</label>
                 </div>
                 <div className="settings">
-                    Game Mode:
-                    <input
-                        type="radio"
-                        id="normal-game"
-                        name="game-mode"
-                        checked={captureGame === false}
-                        onChange={() => handleGameModeChange(false)}
-                    />
-                    <label htmlFor="normal-game">Normal</label>
-                    <input
-                        type="radio"
-                        id="first-capture"
-                        name="game-mode"
-                        checked={captureGame === true}
-                        onChange={() => handleGameModeChange(true)}
-                    />
-                    <label htmlFor="first-capture">1st Capture</label>
+                    <div className="gamemode-spacer">
+                        Game Mode:
+                        <input
+                            type="radio"
+                            id="normal-game"
+                            name="game-mode"
+                            checked={captureGame === false}
+                            onChange={() => handleGameModeChange(false)}
+                        />
+                        <label htmlFor="normal-game">Normal</label>
+                        <input
+                            type="radio"
+                            id="first-capture"
+                            name="game-mode"
+                            checked={captureGame === true}
+                            onChange={() => handleGameModeChange(true)}
+                        />
+                        <label htmlFor="first-capture">1st Capture</label>
+                    </div>
                 </div>
 
                 <button

--- a/src/views/Matchmaking/Matchmaking.tsx
+++ b/src/views/Matchmaking/Matchmaking.tsx
@@ -422,7 +422,7 @@ export function Matchmaking(): JSX.Element {
                             checked={captureGame === false}
                             onChange={() => handleGameModeChange(false)}
                         />
-                        <label htmlFor="normal-game">Normal</label>
+                        <label htmlFor="normal-game">Regular Go</label>
                         <input
                             type="radio"
                             id="first-capture"
@@ -430,7 +430,7 @@ export function Matchmaking(): JSX.Element {
                             checked={captureGame === true}
                             onChange={() => handleGameModeChange(true)}
                         />
-                        <label htmlFor="first-capture">1st Capture</label>
+                        <label htmlFor="first-capture">Capture Go</label>
                     </div>
                 </div>
 

--- a/src/views/Matchmaking/Matchmaking.tsx
+++ b/src/views/Matchmaking/Matchmaking.tsx
@@ -377,18 +377,21 @@ export function Matchmaking(): JSX.Element {
                             <img src={white_svg_url} alt="white" />
                         </label>
                     </div>
-                    {my_color === "black" ? " with " : " and give "}
-                    <select
-                        value={handicap}
-                        onChange={(ev) => setHandicap(parseInt(ev.target.value))}
-                    >
-                        <option value="0">no</option>
-                        <option value="2">2</option>
-                        <option value="3">3</option>
-                        <option value="4">4</option>
-                        <option value="5">5</option>
-                    </select>
-                    {handicap === 1 ? " starting stone and no komi " : " extra stones. "}
+                    {!captureGame && (my_color === "black" ? " with " : " and give ")}
+                    {!captureGame && (
+                        <select
+                            value={handicap}
+                            onChange={(ev) => setHandicap(parseInt(ev.target.value))}
+                        >
+                            <option value="0">no</option>
+                            <option value="2">2</option>
+                            <option value="3">3</option>
+                            <option value="4">4</option>
+                            <option value="5">5</option>
+                        </select>
+                    )}
+                    {!captureGame &&
+                        (handicap === 1 ? " starting stone and no komi " : " extra stones. ")}
                 </div>
                 <div className="settings">
                     Board size:

--- a/src/views/Matchmaking/Matchmaking.tsx
+++ b/src/views/Matchmaking/Matchmaking.tsx
@@ -229,7 +229,7 @@ export function Matchmaking(): JSX.Element {
                 }
 
                 function checkForReject(notification) {
-                    // console.log("challenge rejection check notification:", notification);
+                    console.log("challenge rejection check notification:", notification);
                     if (notification.type === "gameOfferRejected") {
                         /* non checked delete to purge old notifications that
                          * could be around after browser refreshes, connection

--- a/src/views/Matchmaking/Matchmaking.tsx
+++ b/src/views/Matchmaking/Matchmaking.tsx
@@ -52,7 +52,8 @@ export function Matchmaking(): JSX.Element {
     const [race, idx] = uiClassToRaceIdx(user.ui_class);
     const [my_color, setMyColor] = React.useState<"black" | "white">("black");
     const [board_size, setBoardSize] = React.useState(9);
-
+    const [captureGame, setCaptureGame] = React.useState(false);
+    console.log("captureGame", captureGame);
     useEnsureUserIsCreated();
 
     // setup redirect back to home after an hour of inactivity
@@ -246,6 +247,7 @@ export function Matchmaking(): JSX.Element {
             play(e);
         }
     };
+
     function back() {
         void navigate("/");
     }
@@ -393,6 +395,22 @@ export function Matchmaking(): JSX.Element {
                         onChange={() => setBoardSize(13)}
                     />
                     <label htmlFor="board-size-13">13x13</label>
+                    <input
+                        type="radio"
+                        id="normal-game"
+                        name="game-mode"
+                        checked={captureGame === false}
+                        onChange={() => setCaptureGame(false)}
+                    />
+                    <label htmlFor="normal-game">Normal Game</label>
+                    <input
+                        type="radio"
+                        id="first-capture"
+                        name="game-mode"
+                        checked={captureGame === true}
+                        onChange={() => setCaptureGame(true)}
+                    />
+                    <label htmlFor="first-capture">Capture Game</label>
                 </div>
 
                 <button

--- a/src/views/Matchmaking/Matchmaking.tsx
+++ b/src/views/Matchmaking/Matchmaking.tsx
@@ -53,7 +53,18 @@ export function Matchmaking(): JSX.Element {
     const [my_color, setMyColor] = React.useState<"black" | "white">("black");
     const [board_size, setBoardSize] = React.useState(9);
     const [captureGame, setCaptureGame] = React.useState(false);
-    console.log("captureGame", captureGame);
+
+    const handleGameModeChange = (isCaptureMode: boolean) => {
+        setCaptureGame(isCaptureMode);
+
+        // Sync to localStorage so kidsgo-routes.tsx can load the proper query parameter if we are playing the capture game
+        if (isCaptureMode) {
+            localStorage.setItem("gameMode", "capture");
+        } else {
+            localStorage.removeItem("gameMode");
+        }
+    };
+
     useEnsureUserIsCreated();
 
     // setup redirect back to home after an hour of inactivity
@@ -395,22 +406,25 @@ export function Matchmaking(): JSX.Element {
                         onChange={() => setBoardSize(13)}
                     />
                     <label htmlFor="board-size-13">13x13</label>
+                </div>
+                <div className="settings">
+                    Game Mode:
                     <input
                         type="radio"
                         id="normal-game"
                         name="game-mode"
                         checked={captureGame === false}
-                        onChange={() => setCaptureGame(false)}
+                        onChange={() => handleGameModeChange(false)}
                     />
-                    <label htmlFor="normal-game">Normal Game</label>
+                    <label htmlFor="normal-game">Normal</label>
                     <input
                         type="radio"
                         id="first-capture"
                         name="game-mode"
                         checked={captureGame === true}
-                        onChange={() => setCaptureGame(true)}
+                        onChange={() => handleGameModeChange(true)}
                     />
-                    <label htmlFor="first-capture">Capture Game</label>
+                    <label htmlFor="first-capture">1st Capture</label>
                 </div>
 
                 <button

--- a/src/views/Matchmaking/Matchmaking.tsx
+++ b/src/views/Matchmaking/Matchmaking.tsx
@@ -52,7 +52,9 @@ export function Matchmaking(): JSX.Element {
     const [race, idx] = uiClassToRaceIdx(user.ui_class);
     const [my_color, setMyColor] = React.useState<"black" | "white">("black");
     const [board_size, setBoardSize] = React.useState(9);
-    const [captureGame, setCaptureGame] = React.useState(false);
+    const [captureGame, setCaptureGame] = React.useState(() => {
+        return localStorage.getItem("gameMode") === "capture";
+    });
 
     const handleGameModeChange = (isCaptureMode: boolean) => {
         setCaptureGame(isCaptureMode);

--- a/src/views/Matchmaking/Matchmaking.tsx
+++ b/src/views/Matchmaking/Matchmaking.tsx
@@ -335,6 +335,7 @@ export function Matchmaking(): JSX.Element {
                             channel="kidsgo"
                             value={opponent}
                             handicap={handicap}
+                            captureGame={captureGame}
                             onChange={setOpponentAndHandicap}
                         />
                     </div>
@@ -386,7 +387,6 @@ export function Matchmaking(): JSX.Element {
                         <option value="3">3</option>
                         <option value="4">4</option>
                         <option value="5">5</option>
-                        {/* <option value="6">6</option> */}
                     </select>
                     {handicap === 1 ? " starting stone and no komi " : " extra stones. "}
                 </div>


### PR DESCRIPTION
What was done:

- Added a first capture game mode option, which uses a query parameter appended to the original functioning route: 

```
/game/<game_id>/?mode=capture
```
- The game instantly ends when someone captures a stone or a group of stones
- The pop-up modal shows a different message compared to the resignation message

Things to look out for in the future:

1. I'm resigning the current user (regardless of if they won or lost) to lock the Goban and make it unclickable.   This is nice because the resigned board state means the territory doesn't show up.  Around 80% of the time, an error message will briefly pop up in the results dialog, which I've suppressed in this PR, but it still appears in the browser console.

```
ERROR:  Error: Game is not in progress [phase=finished] last_move 8 B6. Player to move:  white 2064
```

2. Because the winner could be the user who won (we always resign the current user, even if they won to lock the Goban), I save the winner id in localStorage to keep track of the winner for the ResultsDialog component.  The issue is the Goban state still thinks the user lost, so there could be potential issues later with this inconsistent state.

3. When the user wins and thus resigns, it forces the opponent to pass a stone, which means the user's prisoner bowl contains one extra capture.  I've made it so we don't count passes as captures only in the capture game mode.

4. The query string for capture mode sometimes doesn't append to the url for some reason, so I added some code to check for that against localStorage, and if there's an inconsistent state, it adds the query string back.  Otherwise there's a bug like 1/10 times where the user has the capture game mode selected, but they don't actually get that game mode when they play the game.  
